### PR TITLE
type bool is flag

### DIFF
--- a/README.md
+++ b/README.md
@@ -167,11 +167,22 @@ output: Path = classyclick.option()
 other_output: Any = classyclick.option(type=str)
 ```
 
+When type is `bool`, it will set `is_flag=True` as well. If for some reason you don't want that, it can still be overriden.
+
+```python
+# This results in click.option('--verbose', type=bool, is_flag=True)
+verbose: bool = classyclick.option()
+
+# As mentioned, it can always be overriden if you need the weird behavior of a non-flag bool option...
+weird: bool = classyclick.option(is_flag=False)
+```
+
 ### classyclick.argument
 
 Similar to `classyclick.option`, this is mostly wrapping [@click.argument](https://click.palletsprojects.com/en/stable/api/#click.argument) so it can be used in fields.
 
-Argument name is inferred from the field name and type from field.type. Again, type can be overriden, however not argument name as it has to match the property. For display purposes, you can use `metavar=`.
+Argument name is inferred from the field name and, same as `classyclick.option`, type from field.type.  
+Again, type can be overriden, however not argument name as it has to match the property. For display purposes, you can use `metavar=`.
 
 ```python
 @classyclick.command()

--- a/classyclick/fields.py
+++ b/classyclick/fields.py
@@ -82,4 +82,7 @@ class ClassyOption(ClassyField):
         if 'type' not in self.attrs:
             self.attrs['type'] = field.type
 
+        if self.attrs['type'] is bool and 'is_flag' not in self.attrs:
+            self.attrs['is_flag'] = True
+
         click.option(*param_decls, **self.attrs)(command)

--- a/tests/test_command_option.py
+++ b/tests/test_command_option.py
@@ -68,3 +68,31 @@ class Test(BaseCase):
         result = runner.invoke(DP, ['--name', 'world', '--xtra', '!'])
         self.assertEqual(result.exit_code, 0)
         self.assertEqual(result.output, 'Hello, world!\n')
+
+    def test_type_bool(self):
+        """test implicit is_flag=True for type bool"""
+
+        @classyclick.command()
+        class DP:
+            greet: bool = classyclick.option()
+            other: bool = classyclick.option(is_flag=False)
+
+            def __call__(self):
+                if self.greet:
+                    print('Hello')
+
+        runner = CliRunner()
+
+        result = runner.invoke(DP, ['--help'])
+        self.assertEqual(result.exit_code, 0)
+        self.assertRegex(result.output, r'\n  --greet\n')
+        # when is_flag=False, even with type=bool, help reflects it
+        self.assertRegex(result.output, r'\n  --other BOOLEAN\n')
+
+        result = runner.invoke(DP, [])
+        self.assertEqual(result.exit_code, 0)
+        self.assertEqual(result.output, '')
+
+        result = runner.invoke(DP, ['--greet'])
+        self.assertEqual(result.exit_code, 0)
+        self.assertEqual(result.output, 'Hello\n')


### PR DESCRIPTION
Unclear which use case `click` covers by *not* making every `type=bool` a flag.

This PR introduces that at least in `classyclick`, as the main goal is reduce as much as possible `option` and `argument` parameters.

This means that if a field type is `bool`, it will not only get `type=bool` but also `is_flag=True`. Both can still be overriden by making them explicit in the option parameters (`classyclick.option(..., is_flag=False, ...)`)