### PR TITLE
infer correct click.option type when using `multiple=True`

### DIFF
--- a/classyclick/fields.py
+++ b/classyclick/fields.py
@@ -1,5 +1,5 @@
 from dataclasses import dataclass
-from typing import TYPE_CHECKING, Any
+from typing import TYPE_CHECKING, Any, get_args, get_origin
 
 if TYPE_CHECKING:
     from dataclasses import Field
@@ -80,7 +80,10 @@ class ClassyOption(ClassyField):
                 param_decls = (long_name,) + param_decls
 
         if 'type' not in self.attrs:
-            self.attrs['type'] = field.type
+            if self.attrs.get('multiple', False) and get_origin(field.type) is list:
+                self.attrs['type'] = get_args(field.type)[0]
+            else:
+                self.attrs['type'] = field.type
 
         if self.attrs['type'] is bool and 'is_flag' not in self.attrs:
             self.attrs['is_flag'] = True

--- a/tests/test_command_option.py
+++ b/tests/test_command_option.py
@@ -96,3 +96,24 @@ class Test(BaseCase):
         result = runner.invoke(DP, ['--greet'])
         self.assertEqual(result.exit_code, 0)
         self.assertEqual(result.output, 'Hello\n')
+
+    def test_type_list_multiple(self):
+        """test click type is properly set to X when using field type list[X]"""
+
+        @classyclick.command()
+        class DP:
+            names: list[str] = classyclick.option('--name', default_parameter=False, metavar='NAME', multiple=True)
+
+            def __call__(self):
+                print(f'Hello, {" and ".join(self.names)}')
+
+        runner = CliRunner()
+
+        result = runner.invoke(DP, ['--help'])
+        self.assertEqual(result.exit_code, 0)
+        self.assertRegex(result.output, r'\n  --name NAME\n')
+
+        result = runner.invoke(DP, ['--name', 'john', '--name', 'paul'])
+        self.assertEqual(result.exception, None)
+        self.assertEqual(result.exit_code, 0)
+        self.assertEqual(result.output, 'Hello, john and paul\n')


### PR DESCRIPTION
Fixes #15 