### PR TITLE
refactor to REAL class - breaking change

### DIFF
--- a/README.md
+++ b/README.md
@@ -305,7 +305,7 @@ from hello import Hello
 
 def test_hello_world():
   runner = CliRunner()
-  result = runner.invoke(Hello, ['--name', 'Peter'])
+  result = runner.invoke(Hello.click, ['--name', 'Peter'])
   assert result.exit_code == 0
   assert result.output == 'Hello reteP!\n'
 ```

--- a/README.md
+++ b/README.md
@@ -34,8 +34,7 @@ class Hello:
 
 
 if __name__ == '__main__':
-    # not really instantiating (old) Hello class but calling the new click-wrapping "Hello" function
-    Hello()
+    Hello.click()
 ```
 
 ```
@@ -260,9 +259,7 @@ class Next:
 
 You can compose commands together as the wrapped class is just a `dataclass`.
 
-Only thing to remember is that the original wrapped class is stored in `Command.classy`, as `Command` becomes a function after being decorated.
-
-As example, if we wanted a `Bye` command just like the `Hello` example above, but with a small change, we can subclass `Hello.classy`
+As example, if we wanted a `Bye` command just like the `Hello` example above, but with a small change, we can subclass `Hello`
 
 ```python
 import click
@@ -270,7 +267,7 @@ import classyclick
 
 
 @classyclick.command()
-class Bye(Hello.classy):
+class Bye(Hello):
     """Simple program that says bye to NAME for a total of COUNT times."""
 
     def greet(self):
@@ -297,10 +294,11 @@ Options:
 
 `classyclick` is just a small wrapper around `click`, testing is the same as in [click's docs](https://click.palletsprojects.com/en/stable/testing/#basic-testing):
 
+Simply use `Command.click` with `CliRunner` for the same `click.testing` experience
+
 ```python
 from click.testing import CliRunner
 # Hello being the example above that reverses name
-# notice that the wrapped `click.command` gets the same casing as the class
 from hello import Hello
 
 def test_hello_world():
@@ -310,16 +308,15 @@ def test_hello_world():
   assert result.output == 'Hello reteP!\n'
 ```
 
-For unit testing specific methods of a command, you might want to skip `CliRunner` and use the original class instead, available at `Hello.classy` (from the example)
+But you can also unit test specific methods of a command, skipping `CliRunner`.
 
 This might help reducing required test setup as you don't need to control complex code paths from entrypoint of the CLI command.
 
 ```python
-# notice that the wrapped `click.command` gets the same casing as the class
 from hello import Hello
 
 def test_hello_world():
 # for the example above that reverses the name
-o = Hello.classy('hello', 1)
+o = Hello('hello', 1)
 assert o.reversed_name == 'olleh'
 ```

--- a/classyclick/command.py
+++ b/classyclick/command.py
@@ -8,6 +8,8 @@ T = TypeVar('T')
 
 
 class Clickable(Protocol):
+    """to merge with wrapped classed for type hints"""
+
     def click() -> Callable: ...
 
 

--- a/classyclick/command.py
+++ b/classyclick/command.py
@@ -1,7 +1,14 @@
 from dataclasses import dataclass, fields
+from typing import Callable, Protocol, TypeVar, Union
 
 from . import utils
 from .fields import ClassyField
+
+T = TypeVar('T')
+
+
+class Clickable(Protocol):
+    def click() -> Callable: ...
 
 
 def command(group=None, **click_kwargs):
@@ -11,7 +18,7 @@ def command(group=None, **click_kwargs):
 
         group = click
 
-    def _wrapper(kls):
+    def _wrapper(kls: T) -> Union[T, Clickable]:
         if not hasattr(kls, '__bases__'):
             name = getattr(kls, '__name__', str(kls))
             raise ValueError(f'{name} is not a class - classy stands for classes! Use @click.command instead?')
@@ -31,9 +38,6 @@ def command(group=None, **click_kwargs):
             kls(*args, **kwargs)()
 
         func.__doc__ = kls.__doc__
-        # deprecated: reference moved to `Command.classy` instead to be more accessible (than `Command.callback._classy_`)
-        func._classy_ = kls
-        func.classy = kls
 
         # at the end so it doesn't affect __doc__ or others
         _strictly_typed_dataclass(kls)
@@ -45,9 +49,10 @@ def command(group=None, **click_kwargs):
                 func = field.default(func, field)
 
         command = group.command(**click_kwargs)(func)
-        command.classy = kls
 
-        return command
+        kls.click = command
+
+        return kls
 
     return _wrapper
 

--- a/classyclick/command.py
+++ b/classyclick/command.py
@@ -38,6 +38,7 @@ def command(group=None, **click_kwargs):
             kls(*args, **kwargs)()
 
         func.__doc__ = kls.__doc__
+        func.__name__ = click_kwargs['name']
 
         # at the end so it doesn't affect __doc__ or others
         _strictly_typed_dataclass(kls)

--- a/classyclick/fields.py
+++ b/classyclick/fields.py
@@ -98,9 +98,7 @@ class ClassyOption(ClassyField):
     def __call__(self, command: 'Command', field: 'Field'):
         for param in self.param_decls:
             if param[0] != '-':
-                raise TypeError(
-                    f'{command.classy.__module__}.{command.classy.__qualname__} option {field.name}: do not specify a name, it is already added'
-                )
+                raise TypeError(f'{command.__name__} option {field.name}: do not specify a name, it is already added')
 
         # bake field.name as option name
         param_decls = (field.name,) + self.param_decls

--- a/tests/cli_three.py
+++ b/tests/cli_three.py
@@ -11,7 +11,7 @@ from tests.cli_one import Hello
 
 
 @classyclick.command()
-class Bye(Hello.classy):
+class Bye(Hello):
     """Simple program that says bye to NAME for a total of COUNT times."""
 
     def __call__(self):

--- a/tests/test_clis.py
+++ b/tests/test_clis.py
@@ -8,13 +8,13 @@ from .cli_one import Hello
 class Test(TestCase):
     def test_hello(self):
         runner = CliRunner()
-        result = runner.invoke(Hello, args=['--name', 'classyclick'])
+        result = runner.invoke(Hello.click, args=['--name', 'classyclick'])
 
         self.assertEqual(result.exit_code, 0)
         self.assertIn('Hello, classyclick!', result.output)
 
     def test_hello_class(self):
-        kls = Hello.classy
+        kls = Hello
         kls(name='classyclick')
 
     def test_hello_no_types(self):
@@ -30,7 +30,7 @@ class Test(TestCase):
         from .cli_three import Bye
 
         runner = CliRunner()
-        result = runner.invoke(Bye, args=['--name', 'classyclick'])
+        result = runner.invoke(Bye.click, args=['--name', 'classyclick'])
 
         self.assertEqual(result.exit_code, 0)
         self.assertIn('Bye, classyclick!', result.output)
@@ -39,7 +39,7 @@ class Test(TestCase):
         from .cli_four import Next
 
         runner = CliRunner()
-        result = runner.invoke(Next, args=['3'])
+        result = runner.invoke(Next.click, args=['3'])
 
         self.assertEqual(result.exit_code, 0)
         self.assertEqual(result.output, '4\n')

--- a/tests/test_command_argument.py
+++ b/tests/test_command_argument.py
@@ -14,13 +14,13 @@ class Test(BaseCase):
                 print(f'Hello, {self.name}')
 
         runner = CliRunner()
-        result = runner.invoke(Hello)
+        result = runner.invoke(Hello.click)
         self.assertEqual(result.exit_code, 2)
 
         # click changed from " ' in 8.0.0
         self.assertRegex(result.output, """Error: Missing argument ['"]NAME['"]""")
 
-        result = runner.invoke(Hello, ['--help'])
+        result = runner.invoke(Hello.click, ['--help'])
         self.assertEqual(result.exit_code, 0)
         self.assertEqual(
             result.output,
@@ -32,7 +32,7 @@ Options:
 """,
         )
 
-        result = runner.invoke(Hello, ['Peter'])
+        result = runner.invoke(Hello.click, ['Peter'])
         self.assertEqual(result.exit_code, 0)
         self.assertEqual(result.output, 'Hello, Peter\n')
 
@@ -45,7 +45,7 @@ Options:
                 print(f'Hello, {self.name}')
 
         runner = CliRunner()
-        result = runner.invoke(Hello, ['--help'])
+        result = runner.invoke(Hello.click, ['--help'])
         self.assertEqual(result.exit_code, 0)
         self.assertEqual(
             result.output,
@@ -57,7 +57,8 @@ Options:
 """,
         )
 
-        result = runner.invoke(Hello, ['Peter'])
+        result = runner.invoke(Hello.click, ['Peter'])
+        self.assertEqual(result.exception, None)
         self.assertEqual(result.exit_code, 0)
         self.assertEqual(result.output, 'Hello, Peter\n')
 
@@ -72,7 +73,7 @@ Options:
                 print(self.a + self.b)
 
         runner = CliRunner()
-        result = runner.invoke(Sum, ['1', '2'])
+        result = runner.invoke(Sum.click, ['1', '2'])
         self.assertEqual(result.exit_code, 0)
         self.assertEqual(result.output, '3\n')
 
@@ -87,7 +88,7 @@ Options:
                 print(self.a + self.b)
 
         runner = CliRunner()
-        result = runner.invoke(Sum, ['1', '2'])
+        result = runner.invoke(Sum.click, ['1', '2'])
         self.assertEqual(result.exit_code, 0)
         self.assertEqual(result.output, '3\n')
 
@@ -106,11 +107,11 @@ Options:
 
         runner = CliRunner()
 
-        result = runner.invoke(DP, ['--help'])
+        result = runner.invoke(DP.click, ['--help'])
         self.assertEqual(result.exit_code, 0)
         self.assertRegex(result.output, r'\[OPTIONS\] NAMES...\n')
 
-        result = runner.invoke(DP, ['john', 'paul'])
+        result = runner.invoke(DP.click, ['john', 'paul'])
         self.assertEqual(
             (
                 result.exception,

--- a/tests/test_command_option.py
+++ b/tests/test_command_option.py
@@ -20,7 +20,7 @@ class Test(BaseCase):
                 print(f'Hello, {self.name}')
 
         runner = CliRunner()
-        result = runner.invoke(Hello, ['--name', 'Peter'])
+        result = runner.invoke(Hello.click, ['--name', 'Peter'])
         self.assertEqual(result.exit_code, 0)
         self.assertEqual(result.output, 'Hello, Peter\n')
 
@@ -34,7 +34,7 @@ class Test(BaseCase):
                 print(self.a + self.b)
 
         runner = CliRunner()
-        result = runner.invoke(Sum, ['--a', '1', '--b', '2'])
+        result = runner.invoke(Sum.click, ['--a', '1', '--b', '2'])
         self.assertEqual(result.exit_code, 0)
         self.assertEqual(result.output, '3\n')
 
@@ -60,12 +60,12 @@ class Test(BaseCase):
 
         runner = CliRunner()
 
-        result = runner.invoke(DP, ['--help'])
+        result = runner.invoke(DP.click, ['--help'])
         self.assertEqual(result.exit_code, 0)
         self.assertRegex(result.output, r'\n  --name TEXT')
         self.assertRegex(result.output, r'\n  --xtra TEXT')
 
-        result = runner.invoke(DP, ['--name', 'world', '--xtra', '!'])
+        result = runner.invoke(DP.click, ['--name', 'world', '--xtra', '!'])
         self.assertEqual(result.exit_code, 0)
         self.assertEqual(result.output, 'Hello, world!\n')
 
@@ -83,17 +83,17 @@ class Test(BaseCase):
 
         runner = CliRunner()
 
-        result = runner.invoke(DP, ['--help'])
+        result = runner.invoke(DP.click, ['--help'])
         self.assertEqual(result.exit_code, 0)
         self.assertRegex(result.output, r'\n  --greet\n')
         # when is_flag=False, even with type=bool, help reflects it
         self.assertRegex(result.output, r'\n  --other BOOLEAN\n')
 
-        result = runner.invoke(DP, [])
+        result = runner.invoke(DP.click, [])
         self.assertEqual(result.exit_code, 0)
         self.assertEqual(result.output, '')
 
-        result = runner.invoke(DP, ['--greet'])
+        result = runner.invoke(DP.click, ['--greet'])
         self.assertEqual(result.exit_code, 0)
         self.assertEqual(result.output, 'Hello\n')
 
@@ -109,11 +109,11 @@ class Test(BaseCase):
 
         runner = CliRunner()
 
-        result = runner.invoke(DP, ['--help'])
+        result = runner.invoke(DP.click, ['--help'])
         self.assertEqual(result.exit_code, 0)
         self.assertRegex(result.output, '\n  --name NAME\n')
 
-        result = runner.invoke(DP, ['--name', 'john', '--name', 'paul'])
+        result = runner.invoke(DP.click, ['--name', 'john', '--name', 'paul'])
         self.assertEqual(result.exception, None)
         self.assertEqual(result.exit_code, 0)
         self.assertEqual(result.output, 'Hello, john and paul\n')
@@ -130,11 +130,11 @@ class Test(BaseCase):
 
         runner = CliRunner()
 
-        result = runner.invoke(DP, ['--help'])
+        result = runner.invoke(DP.click, ['--help'])
         self.assertEqual(result.exit_code, 0)
         self.assertRegex(result.output, '\n  --name NAME\n')
 
-        result = runner.invoke(DP, ['--name', 'john', 'paul'])
+        result = runner.invoke(DP.click, ['--name', 'john', 'paul'])
         self.assertEqual(
             (
                 result.exception,

--- a/tests/test_command_option.py
+++ b/tests/test_command_option.py
@@ -47,7 +47,7 @@ class Test(BaseCase):
                 def __call__(self):
                     print(self.a + self.b)
 
-        self.assertRaisesRegex(TypeError, '.Sum option a: do not specify a name, it is already added', _a)
+        self.assertRaisesRegex(TypeError, 'sum option a: do not specify a name, it is already added', _a)
 
     def test_no_default_parameter(self):
         @classyclick.command()


### PR DESCRIPTION
The current setup, with original class hidden in `Command.classy`, is counter-intuitive: for user and for type hints!

```python
@classyclick.command()
class Hello:
...

if __name__ == '__main__':
    Hello()
```

Is `Hello()` creating a new object?
No, it's calling the command! Only class names are usually capitalized...
Also, type hints will show methods/properties from Hello class when they're not available there (only in Hello.classy)


Again, for class composition

```python
@classyclick.command()
class Bye(Hello.classy):
   ...
```

This does not look nice (having a `.classy`). And for type hints, `classy` is not defined, no `Hello` methods/properties are shown for `Bye` class...

This PR reverses that: wrapped `Hello` becomes the class again and the command is the one exposed in a method `Hello.click()`!

Previous examples updated

```python
@classyclick.command()
class Hello:
...

if __name__ == '__main__':
    Hello.click()
```
```python
@classyclick.command()
class Bye(Hello):
   ...
```