### PR TITLE
more standard interface

### DIFF
--- a/Pipfile
+++ b/Pipfile
@@ -1,5 +1,6 @@
 [packages]
 click = ">=7"
+typing-extensions = ">=4.12.2"
 
 [dev-packages]
 ruff = "*"

--- a/Pipfile.lock
+++ b/Pipfile.lock
@@ -1,11 +1,11 @@
 {
     "_meta": {
         "hash": {
-            "sha256": "d0456ec70dbb5989372982bbbe3ac4009e7d9aba36784083ddbb5fa389aefe80"
+            "sha256": "5d81d703d700f9c887cbf77f1e275dd172beb65983aa5cbc61b89d9ca1bef3e7"
         },
         "pipfile-spec": 6,
         "requires": {
-            "python_version": ">=3.9"
+            "python_version": "3.9"
         },
         "sources": [
             {
@@ -18,12 +18,21 @@
     "default": {
         "click": {
             "hashes": [
-                "sha256:63c132bbbed01578a06712a2d1f497bb62d9c1c0d329b7903a866228027263b2",
-                "sha256:ed53c9d8990d83c2a27deae68e4ee337473f6330c040a31d4225c9574d16096a"
+                "sha256:27c491cc05d968d271d5a1db13e3b5a184636d9d930f148c50b038f0d0646202",
+                "sha256:61a3265b914e850b85317d0b3109c7f8cd35a670f963866005d6ef1d5175a12b"
             ],
             "index": "pypi",
-            "markers": "python_version >= '3.7'",
-            "version": "==8.1.8"
+            "markers": "python_version >= '3.10'",
+            "version": "==8.2.1"
+        },
+        "typing-extensions": {
+            "hashes": [
+                "sha256:a439e7c04b49fec3e5d3e2beaa21755cadbbdc391694e28ccdd36ca4a1408f8c",
+                "sha256:e6c81219bd689f51865d9e372991c540bda33a0379d5573cddb9a3a23f7caaef"
+            ],
+            "index": "pypi",
+            "markers": "python_version >= '3.8'",
+            "version": "==4.13.2"
         }
     },
     "develop": {
@@ -46,181 +55,185 @@
         },
         "certifi": {
             "hashes": [
-                "sha256:3d5da6925056f6f18f119200434a4780a94263f10d1c21d032a6f6b2baa20651",
-                "sha256:ca78db4565a652026a4db2bcdf68f2fb589ea80d0be70e03929ed730746b84fe"
+                "sha256:0a816057ea3cdefcef70270d2c515e4506bbc954f417fa5ade2021213bb8f0c6",
+                "sha256:30350364dfe371162649852c63336a15c70c6510c2ad5015b21c2345311805f3"
             ],
             "markers": "python_version >= '3.6'",
-            "version": "==2025.1.31"
+            "version": "==2025.4.26"
         },
         "charset-normalizer": {
             "hashes": [
-                "sha256:0167ddc8ab6508fe81860a57dd472b2ef4060e8d378f0cc555707126830f2537",
-                "sha256:01732659ba9b5b873fc117534143e4feefecf3b2078b0a6a2e925271bb6f4cfa",
-                "sha256:01ad647cdd609225c5350561d084b42ddf732f4eeefe6e678765636791e78b9a",
-                "sha256:04432ad9479fa40ec0f387795ddad4437a2b50417c69fa275e212933519ff294",
-                "sha256:0907f11d019260cdc3f94fbdb23ff9125f6b5d1039b76003b5b0ac9d6a6c9d5b",
-                "sha256:0924e81d3d5e70f8126529951dac65c1010cdf117bb75eb02dd12339b57749dd",
-                "sha256:09b26ae6b1abf0d27570633b2b078a2a20419c99d66fb2823173d73f188ce601",
-                "sha256:09b5e6733cbd160dcc09589227187e242a30a49ca5cefa5a7edd3f9d19ed53fd",
-                "sha256:0af291f4fe114be0280cdd29d533696a77b5b49cfde5467176ecab32353395c4",
-                "sha256:0f55e69f030f7163dffe9fd0752b32f070566451afe180f99dbeeb81f511ad8d",
-                "sha256:1a2bc9f351a75ef49d664206d51f8e5ede9da246602dc2d2726837620ea034b2",
-                "sha256:22e14b5d70560b8dd51ec22863f370d1e595ac3d024cb8ad7d308b4cd95f8313",
-                "sha256:234ac59ea147c59ee4da87a0c0f098e9c8d169f4dc2a159ef720f1a61bbe27cd",
-                "sha256:2369eea1ee4a7610a860d88f268eb39b95cb588acd7235e02fd5a5601773d4fa",
-                "sha256:237bdbe6159cff53b4f24f397d43c6336c6b0b42affbe857970cefbb620911c8",
-                "sha256:28bf57629c75e810b6ae989f03c0828d64d6b26a5e205535585f96093e405ed1",
-                "sha256:2967f74ad52c3b98de4c3b32e1a44e32975e008a9cd2a8cc8966d6a5218c5cb2",
-                "sha256:2a75d49014d118e4198bcee5ee0a6f25856b29b12dbf7cd012791f8a6cc5c496",
-                "sha256:2bdfe3ac2e1bbe5b59a1a63721eb3b95fc9b6817ae4a46debbb4e11f6232428d",
-                "sha256:2d074908e1aecee37a7635990b2c6d504cd4766c7bc9fc86d63f9c09af3fa11b",
-                "sha256:2fb9bd477fdea8684f78791a6de97a953c51831ee2981f8e4f583ff3b9d9687e",
-                "sha256:311f30128d7d333eebd7896965bfcfbd0065f1716ec92bd5638d7748eb6f936a",
-                "sha256:329ce159e82018d646c7ac45b01a430369d526569ec08516081727a20e9e4af4",
-                "sha256:345b0426edd4e18138d6528aed636de7a9ed169b4aaf9d61a8c19e39d26838ca",
-                "sha256:363e2f92b0f0174b2f8238240a1a30142e3db7b957a5dd5689b0e75fb717cc78",
-                "sha256:3a3bd0dcd373514dcec91c411ddb9632c0d7d92aed7093b8c3bbb6d69ca74408",
-                "sha256:3bed14e9c89dcb10e8f3a29f9ccac4955aebe93c71ae803af79265c9ca5644c5",
-                "sha256:44251f18cd68a75b56585dd00dae26183e102cd5e0f9f1466e6df5da2ed64ea3",
-                "sha256:44ecbf16649486d4aebafeaa7ec4c9fed8b88101f4dd612dcaf65d5e815f837f",
-                "sha256:4532bff1b8421fd0a320463030c7520f56a79c9024a4e88f01c537316019005a",
-                "sha256:49402233c892a461407c512a19435d1ce275543138294f7ef013f0b63d5d3765",
-                "sha256:4c0907b1928a36d5a998d72d64d8eaa7244989f7aaaf947500d3a800c83a3fd6",
-                "sha256:4d86f7aff21ee58f26dcf5ae81a9addbd914115cdebcbb2217e4f0ed8982e146",
-                "sha256:5777ee0881f9499ed0f71cc82cf873d9a0ca8af166dfa0af8ec4e675b7df48e6",
-                "sha256:5df196eb874dae23dcfb968c83d4f8fdccb333330fe1fc278ac5ceeb101003a9",
-                "sha256:619a609aa74ae43d90ed2e89bdd784765de0a25ca761b93e196d938b8fd1dbbd",
-                "sha256:6e27f48bcd0957c6d4cb9d6fa6b61d192d0b13d5ef563e5f2ae35feafc0d179c",
-                "sha256:6ff8a4a60c227ad87030d76e99cd1698345d4491638dfa6673027c48b3cd395f",
-                "sha256:73d94b58ec7fecbc7366247d3b0b10a21681004153238750bb67bd9012414545",
-                "sha256:7461baadb4dc00fd9e0acbe254e3d7d2112e7f92ced2adc96e54ef6501c5f176",
-                "sha256:75832c08354f595c760a804588b9357d34ec00ba1c940c15e31e96d902093770",
-                "sha256:7709f51f5f7c853f0fb938bcd3bc59cdfdc5203635ffd18bf354f6967ea0f824",
-                "sha256:78baa6d91634dfb69ec52a463534bc0df05dbd546209b79a3880a34487f4b84f",
-                "sha256:7974a0b5ecd505609e3b19742b60cee7aa2aa2fb3151bc917e6e2646d7667dcf",
-                "sha256:7a4f97a081603d2050bfaffdefa5b02a9ec823f8348a572e39032caa8404a487",
-                "sha256:7b1bef6280950ee6c177b326508f86cad7ad4dff12454483b51d8b7d673a2c5d",
-                "sha256:7d053096f67cd1241601111b698f5cad775f97ab25d81567d3f59219b5f1adbd",
-                "sha256:804a4d582ba6e5b747c625bf1255e6b1507465494a40a2130978bda7b932c90b",
-                "sha256:807f52c1f798eef6cf26beb819eeb8819b1622ddfeef9d0977a8502d4db6d534",
-                "sha256:80ed5e856eb7f30115aaf94e4a08114ccc8813e6ed1b5efa74f9f82e8509858f",
-                "sha256:8417cb1f36cc0bc7eaba8ccb0e04d55f0ee52df06df3ad55259b9a323555fc8b",
-                "sha256:8436c508b408b82d87dc5f62496973a1805cd46727c34440b0d29d8a2f50a6c9",
-                "sha256:89149166622f4db9b4b6a449256291dc87a99ee53151c74cbd82a53c8c2f6ccd",
-                "sha256:8bfa33f4f2672964266e940dd22a195989ba31669bd84629f05fab3ef4e2d125",
-                "sha256:8c60ca7339acd497a55b0ea5d506b2a2612afb2826560416f6894e8b5770d4a9",
-                "sha256:91b36a978b5ae0ee86c394f5a54d6ef44db1de0815eb43de826d41d21e4af3de",
-                "sha256:955f8851919303c92343d2f66165294848d57e9bba6cf6e3625485a70a038d11",
-                "sha256:97f68b8d6831127e4787ad15e6757232e14e12060bec17091b85eb1486b91d8d",
-                "sha256:9b23ca7ef998bc739bf6ffc077c2116917eabcc901f88da1b9856b210ef63f35",
-                "sha256:9f0b8b1c6d84c8034a44893aba5e767bf9c7a211e313a9605d9c617d7083829f",
-                "sha256:aabfa34badd18f1da5ec1bc2715cadc8dca465868a4e73a0173466b688f29dda",
-                "sha256:ab36c8eb7e454e34e60eb55ca5d241a5d18b2c6244f6827a30e451c42410b5f7",
-                "sha256:b010a7a4fd316c3c484d482922d13044979e78d1861f0e0650423144c616a46a",
-                "sha256:b1ac5992a838106edb89654e0aebfc24f5848ae2547d22c2c3f66454daa11971",
-                "sha256:b7b2d86dd06bfc2ade3312a83a5c364c7ec2e3498f8734282c6c3d4b07b346b8",
-                "sha256:b97e690a2118911e39b4042088092771b4ae3fc3aa86518f84b8cf6888dbdb41",
-                "sha256:bc2722592d8998c870fa4e290c2eec2c1569b87fe58618e67d38b4665dfa680d",
-                "sha256:c0429126cf75e16c4f0ad00ee0eae4242dc652290f940152ca8c75c3a4b6ee8f",
-                "sha256:c30197aa96e8eed02200a83fba2657b4c3acd0f0aa4bdc9f6c1af8e8962e0757",
-                "sha256:c4c3e6da02df6fa1410a7680bd3f63d4f710232d3139089536310d027950696a",
-                "sha256:c75cb2a3e389853835e84a2d8fb2b81a10645b503eca9bcb98df6b5a43eb8886",
-                "sha256:c96836c97b1238e9c9e3fe90844c947d5afbf4f4c92762679acfe19927d81d77",
-                "sha256:d7f50a1f8c450f3925cb367d011448c39239bb3eb4117c36a6d354794de4ce76",
-                "sha256:d973f03c0cb71c5ed99037b870f2be986c3c05e63622c017ea9816881d2dd247",
-                "sha256:d98b1668f06378c6dbefec3b92299716b931cd4e6061f3c875a71ced1780ab85",
-                "sha256:d9c3cdf5390dcd29aa8056d13e8e99526cda0305acc038b96b30352aff5ff2bb",
-                "sha256:dad3e487649f498dd991eeb901125411559b22e8d7ab25d3aeb1af367df5efd7",
-                "sha256:dccbe65bd2f7f7ec22c4ff99ed56faa1e9f785482b9bbd7c717e26fd723a1d1e",
-                "sha256:dd78cfcda14a1ef52584dbb008f7ac81c1328c0f58184bf9a84c49c605002da6",
-                "sha256:e218488cd232553829be0664c2292d3af2eeeb94b32bea483cf79ac6a694e037",
-                "sha256:e358e64305fe12299a08e08978f51fc21fac060dcfcddd95453eabe5b93ed0e1",
-                "sha256:ea0d8d539afa5eb2728aa1932a988a9a7af94f18582ffae4bc10b3fbdad0626e",
-                "sha256:eab677309cdb30d047996b36d34caeda1dc91149e4fdca0b1a039b3f79d9a807",
-                "sha256:eb8178fe3dba6450a3e024e95ac49ed3400e506fd4e9e5c32d30adda88cbd407",
-                "sha256:ecddf25bee22fe4fe3737a399d0d177d72bc22be6913acfab364b40bce1ba83c",
-                "sha256:eea6ee1db730b3483adf394ea72f808b6e18cf3cb6454b4d86e04fa8c4327a12",
-                "sha256:f08ff5e948271dc7e18a35641d2f11a4cd8dfd5634f55228b691e62b37125eb3",
-                "sha256:f30bf9fd9be89ecb2360c7d94a711f00c09b976258846efe40db3d05828e8089",
-                "sha256:fa88b843d6e211393a37219e6a1c1df99d35e8fd90446f1118f4216e307e48cd",
-                "sha256:fc54db6c8593ef7d4b2a331b58653356cf04f67c960f584edb7c3d8c97e8f39e",
-                "sha256:fd4ec41f914fa74ad1b8304bbc634b3de73d2a0889bd32076342a573e0779e00",
-                "sha256:ffc9202a29ab3920fa812879e95a9e78b2465fd10be7fcbd042899695d75e616"
+                "sha256:005fa3432484527f9732ebd315da8da8001593e2cf46a3d817669f062c3d9ed4",
+                "sha256:046595208aae0120559a67693ecc65dd75d46f7bf687f159127046628178dc45",
+                "sha256:0c29de6a1a95f24b9a1aa7aefd27d2487263f00dfd55a77719b530788f75cff7",
+                "sha256:0c8c57f84ccfc871a48a47321cfa49ae1df56cd1d965a09abe84066f6853b9c0",
+                "sha256:0f5d9ed7f254402c9e7d35d2f5972c9bbea9040e99cd2861bd77dc68263277c7",
+                "sha256:18dd2e350387c87dabe711b86f83c9c78af772c748904d372ade190b5c7c9d4d",
+                "sha256:1b1bde144d98e446b056ef98e59c256e9294f6b74d7af6846bf5ffdafd687a7d",
+                "sha256:1c95a1e2902a8b722868587c0e1184ad5c55631de5afc0eb96bc4b0d738092c0",
+                "sha256:1cad5f45b3146325bb38d6855642f6fd609c3f7cad4dbaf75549bf3b904d3184",
+                "sha256:21b2899062867b0e1fde9b724f8aecb1af14f2778d69aacd1a5a1853a597a5db",
+                "sha256:24498ba8ed6c2e0b56d4acbf83f2d989720a93b41d712ebd4f4979660db4417b",
+                "sha256:25a23ea5c7edc53e0f29bae2c44fcb5a1aa10591aae107f2a2b2583a9c5cbc64",
+                "sha256:289200a18fa698949d2b39c671c2cc7a24d44096784e76614899a7ccf2574b7b",
+                "sha256:28a1005facc94196e1fb3e82a3d442a9d9110b8434fc1ded7a24a2983c9888d8",
+                "sha256:32fc0341d72e0f73f80acb0a2c94216bd704f4f0bce10aedea38f30502b271ff",
+                "sha256:36b31da18b8890a76ec181c3cf44326bf2c48e36d393ca1b72b3f484113ea344",
+                "sha256:3c21d4fca343c805a52c0c78edc01e3477f6dd1ad7c47653241cf2a206d4fc58",
+                "sha256:3fddb7e2c84ac87ac3a947cb4e66d143ca5863ef48e4a5ecb83bd48619e4634e",
+                "sha256:43e0933a0eff183ee85833f341ec567c0980dae57c464d8a508e1b2ceb336471",
+                "sha256:4a476b06fbcf359ad25d34a057b7219281286ae2477cc5ff5e3f70a246971148",
+                "sha256:4e594135de17ab3866138f496755f302b72157d115086d100c3f19370839dd3a",
+                "sha256:50bf98d5e563b83cc29471fa114366e6806bc06bc7a25fd59641e41445327836",
+                "sha256:5a9979887252a82fefd3d3ed2a8e3b937a7a809f65dcb1e068b090e165bbe99e",
+                "sha256:5baececa9ecba31eff645232d59845c07aa030f0c81ee70184a90d35099a0e63",
+                "sha256:5bf4545e3b962767e5c06fe1738f951f77d27967cb2caa64c28be7c4563e162c",
+                "sha256:6333b3aa5a12c26b2a4d4e7335a28f1475e0e5e17d69d55141ee3cab736f66d1",
+                "sha256:65c981bdbd3f57670af8b59777cbfae75364b483fa8a9f420f08094531d54a01",
+                "sha256:68a328e5f55ec37c57f19ebb1fdc56a248db2e3e9ad769919a58672958e8f366",
+                "sha256:6a0289e4589e8bdfef02a80478f1dfcb14f0ab696b5a00e1f4b8a14a307a3c58",
+                "sha256:6b66f92b17849b85cad91259efc341dce9c1af48e2173bf38a85c6329f1033e5",
+                "sha256:6c9379d65defcab82d07b2a9dfbfc2e95bc8fe0ebb1b176a3190230a3ef0e07c",
+                "sha256:6fc1f5b51fa4cecaa18f2bd7a003f3dd039dd615cd69a2afd6d3b19aed6775f2",
+                "sha256:70f7172939fdf8790425ba31915bfbe8335030f05b9913d7ae00a87d4395620a",
+                "sha256:721c76e84fe669be19c5791da68232ca2e05ba5185575086e384352e2c309597",
+                "sha256:7222ffd5e4de8e57e03ce2cef95a4c43c98fcb72ad86909abdfc2c17d227fc1b",
+                "sha256:75d10d37a47afee94919c4fab4c22b9bc2a8bf7d4f46f87363bcf0573f3ff4f5",
+                "sha256:76af085e67e56c8816c3ccf256ebd136def2ed9654525348cfa744b6802b69eb",
+                "sha256:770cab594ecf99ae64c236bc9ee3439c3f46be49796e265ce0cc8bc17b10294f",
+                "sha256:7a6ab32f7210554a96cd9e33abe3ddd86732beeafc7a28e9955cdf22ffadbab0",
+                "sha256:7c48ed483eb946e6c04ccbe02c6b4d1d48e51944b6db70f697e089c193404941",
+                "sha256:7f56930ab0abd1c45cd15be65cc741c28b1c9a34876ce8c17a2fa107810c0af0",
+                "sha256:8075c35cd58273fee266c58c0c9b670947c19df5fb98e7b66710e04ad4e9ff86",
+                "sha256:8272b73e1c5603666618805fe821edba66892e2870058c94c53147602eab29c7",
+                "sha256:82d8fd25b7f4675d0c47cf95b594d4e7b158aca33b76aa63d07186e13c0e0ab7",
+                "sha256:844da2b5728b5ce0e32d863af26f32b5ce61bc4273a9c720a9f3aa9df73b1455",
+                "sha256:8755483f3c00d6c9a77f490c17e6ab0c8729e39e6390328e42521ef175380ae6",
+                "sha256:915f3849a011c1f593ab99092f3cecfcb4d65d8feb4a64cf1bf2d22074dc0ec4",
+                "sha256:926ca93accd5d36ccdabd803392ddc3e03e6d4cd1cf17deff3b989ab8e9dbcf0",
+                "sha256:982bb1e8b4ffda883b3d0a521e23abcd6fd17418f6d2c4118d257a10199c0ce3",
+                "sha256:98f862da73774290f251b9df8d11161b6cf25b599a66baf087c1ffe340e9bfd1",
+                "sha256:9cbfacf36cb0ec2897ce0ebc5d08ca44213af24265bd56eca54bee7923c48fd6",
+                "sha256:a370b3e078e418187da8c3674eddb9d983ec09445c99a3a263c2011993522981",
+                "sha256:a955b438e62efdf7e0b7b52a64dc5c3396e2634baa62471768a64bc2adb73d5c",
+                "sha256:aa6af9e7d59f9c12b33ae4e9450619cf2488e2bbe9b44030905877f0b2324980",
+                "sha256:aa88ca0b1932e93f2d961bf3addbb2db902198dca337d88c89e1559e066e7645",
+                "sha256:aaeeb6a479c7667fbe1099af9617c83aaca22182d6cf8c53966491a0f1b7ffb7",
+                "sha256:aaf27faa992bfee0264dc1f03f4c75e9fcdda66a519db6b957a3f826e285cf12",
+                "sha256:b2680962a4848b3c4f155dc2ee64505a9c57186d0d56b43123b17ca3de18f0fa",
+                "sha256:b2d318c11350e10662026ad0eb71bb51c7812fc8590825304ae0bdd4ac283acd",
+                "sha256:b33de11b92e9f75a2b545d6e9b6f37e398d86c3e9e9653c4864eb7e89c5773ef",
+                "sha256:b3daeac64d5b371dea99714f08ffc2c208522ec6b06fbc7866a450dd446f5c0f",
+                "sha256:be1e352acbe3c78727a16a455126d9ff83ea2dfdcbc83148d2982305a04714c2",
+                "sha256:bee093bf902e1d8fc0ac143c88902c3dfc8941f7ea1d6a8dd2bcb786d33db03d",
+                "sha256:c72fbbe68c6f32f251bdc08b8611c7b3060612236e960ef848e0a517ddbe76c5",
+                "sha256:c9e36a97bee9b86ef9a1cf7bb96747eb7a15c2f22bdb5b516434b00f2a599f02",
+                "sha256:cddf7bd982eaa998934a91f69d182aec997c6c468898efe6679af88283b498d3",
+                "sha256:cf713fe9a71ef6fd5adf7a79670135081cd4431c2943864757f0fa3a65b1fafd",
+                "sha256:d11b54acf878eef558599658b0ffca78138c8c3655cf4f3a4a673c437e67732e",
+                "sha256:d41c4d287cfc69060fa91cae9683eacffad989f1a10811995fa309df656ec214",
+                "sha256:d524ba3f1581b35c03cb42beebab4a13e6cdad7b36246bd22541fa585a56cccd",
+                "sha256:daac4765328a919a805fa5e2720f3e94767abd632ae410a9062dff5412bae65a",
+                "sha256:db4c7bf0e07fc3b7d89ac2a5880a6a8062056801b83ff56d8464b70f65482b6c",
+                "sha256:dc7039885fa1baf9be153a0626e337aa7ec8bf96b0128605fb0d77788ddc1681",
+                "sha256:dccab8d5fa1ef9bfba0590ecf4d46df048d18ffe3eec01eeb73a42e0d9e7a8ba",
+                "sha256:dedb8adb91d11846ee08bec4c8236c8549ac721c245678282dcb06b221aab59f",
+                "sha256:e45ba65510e2647721e35323d6ef54c7974959f6081b58d4ef5d87c60c84919a",
+                "sha256:e53efc7c7cee4c1e70661e2e112ca46a575f90ed9ae3fef200f2a25e954f4b28",
+                "sha256:e635b87f01ebc977342e2697d05b56632f5f879a4f15955dfe8cef2448b51691",
+                "sha256:e70e990b2137b29dc5564715de1e12701815dacc1d056308e2b17e9095372a82",
+                "sha256:e8082b26888e2f8b36a042a58307d5b917ef2b1cacab921ad3323ef91901c71a",
+                "sha256:e8323a9b031aa0393768b87f04b4164a40037fb2a3c11ac06a03ffecd3618027",
+                "sha256:e92fca20c46e9f5e1bb485887d074918b13543b1c2a1185e69bb8d17ab6236a7",
+                "sha256:eb30abc20df9ab0814b5a2524f23d75dcf83cde762c161917a2b4b7b55b1e518",
+                "sha256:eba9904b0f38a143592d9fc0e19e2df0fa2e41c3c3745554761c5f6447eedabf",
+                "sha256:ef8de666d6179b009dce7bcb2ad4c4a779f113f12caf8dc77f0162c29d20490b",
+                "sha256:efd387a49825780ff861998cd959767800d54f8308936b21025326de4b5a42b9",
+                "sha256:f0aa37f3c979cf2546b73e8222bbfa3dc07a641585340179d768068e3455e544",
+                "sha256:f4074c5a429281bf056ddd4c5d3b740ebca4d43ffffe2ef4bf4d2d05114299da",
+                "sha256:f69a27e45c43520f5487f27627059b64aaf160415589230992cec34c5e18a509",
+                "sha256:fb707f3e15060adf5b7ada797624a6c6e0138e2a26baa089df64c68ee98e040f",
+                "sha256:fcbe676a55d7445b22c10967bceaaf0ee69407fbe0ece4d032b6eb8d4565982a",
+                "sha256:fdb20a30fe1175ecabed17cbf7812f7b804b8a315a25f24678bcdf120a90077f"
             ],
             "markers": "python_version >= '3.7'",
-            "version": "==3.4.1"
+            "version": "==3.4.2"
         },
         "coverage": {
             "extras": [
                 "toml"
             ],
             "hashes": [
-                "sha256:042e7841a26498fff7a37d6fda770d17519982f5b7d8bf5278d140b67b61095f",
-                "sha256:04bfec25a8ef1c5f41f5e7e5c842f6b615599ca8ba8391ec33a9290d9d2db3a3",
-                "sha256:0915742f4c82208ebf47a2b154a5334155ed9ef9fe6190674b8a46c2fb89cb05",
-                "sha256:18c5ae6d061ad5b3e7eef4363fb27a0576012a7447af48be6c75b88494c6cf25",
-                "sha256:2931f66991175369859b5fd58529cd4b73582461877ecfd859b6549869287ffe",
-                "sha256:2e4b6b87bb0c846a9315e3ab4be2d52fac905100565f4b92f02c445c8799e257",
-                "sha256:3043ba1c88b2139126fc72cb48574b90e2e0546d4c78b5299317f61b7f718b78",
-                "sha256:379fe315e206b14e21db5240f89dc0774bdd3e25c3c58c2c733c99eca96f1ada",
-                "sha256:42421e04069fb2cbcbca5a696c4050b84a43b05392679d4068acbe65449b5c64",
-                "sha256:4dfd9a93db9e78666d178d4f08a5408aa3f2474ad4d0e0378ed5f2ef71640cb6",
-                "sha256:52a523153c568d2c0ef8826f6cc23031dc86cffb8c6aeab92c4ff776e7951b28",
-                "sha256:554fec1199d93ab30adaa751db68acec2b41c5602ac944bb19187cb9a41a8067",
-                "sha256:581a40c7b94921fffd6457ffe532259813fc68eb2bdda60fa8cc343414ce3733",
-                "sha256:5a26c0c795c3e0b63ec7da6efded5f0bc856d7c0b24b2ac84b4d1d7bc578d676",
-                "sha256:5a570cd9bd20b85d1a0d7b009aaf6c110b52b5755c17be6962f8ccd65d1dbd23",
-                "sha256:5aaeb00761f985007b38cf463b1d160a14a22c34eb3f6a39d9ad6fc27cb73008",
-                "sha256:5ac46d0c2dd5820ce93943a501ac5f6548ea81594777ca585bf002aa8854cacd",
-                "sha256:5c8a5c139aae4c35cbd7cadca1df02ea8cf28a911534fc1b0456acb0b14234f3",
-                "sha256:6b8af63b9afa1031c0ef05b217faa598f3069148eeee6bb24b79da9012423b82",
-                "sha256:769773614e676f9d8e8a0980dd7740f09a6ea386d0f383db6821df07d0f08545",
-                "sha256:771eb7587a0563ca5bb6f622b9ed7f9d07bd08900f7589b4febff05f469bea00",
-                "sha256:77af0f6447a582fdc7de5e06fa3757a3ef87769fbb0fdbdeba78c23049140a47",
-                "sha256:7a3d62b3b03b4b6fd41a085f3574874cf946cb4604d2b4d3e8dca8cd570ca501",
-                "sha256:821f7bcbaa84318287115d54becb1915eece6918136c6f91045bb84e2f88739d",
-                "sha256:89b1f4af0d4afe495cd4787a68e00f30f1d15939f550e869de90a86efa7e0814",
-                "sha256:8a1d96e780bdb2d0cbb297325711701f7c0b6f89199a57f2049e90064c29f6bd",
-                "sha256:8a40fcf208e021eb14b0fac6bdb045c0e0cab53105f93ba0d03fd934c956143a",
-                "sha256:8f99eb72bf27cbb167b636eb1726f590c00e1ad375002230607a844d9e9a2318",
-                "sha256:90e7fbc6216ecaffa5a880cdc9c77b7418c1dcb166166b78dbc630d07f278cc3",
-                "sha256:94ec0be97723ae72d63d3aa41961a0b9a6f5a53ff599813c324548d18e3b9e8c",
-                "sha256:95aa6ae391a22bbbce1b77ddac846c98c5473de0372ba5c463480043a07bff42",
-                "sha256:96121edfa4c2dfdda409877ea8608dd01de816a4dc4a0523356067b305e4e17a",
-                "sha256:a1f406a8e0995d654b2ad87c62caf6befa767885301f3b8f6f73e6f3c31ec3a6",
-                "sha256:a321c61477ff8ee705b8a5fed370b5710c56b3a52d17b983d9215861e37b642a",
-                "sha256:a5761c70c017c1b0d21b0815a920ffb94a670c8d5d409d9b38857874c21f70d7",
-                "sha256:a9abbccd778d98e9c7e85038e35e91e67f5b520776781d9a1e2ee9d400869487",
-                "sha256:ad80e6b4a0c3cb6f10f29ae4c60e991f424e6b14219d46f1e7d442b938ee68a4",
-                "sha256:b44674870709017e4b4036e3d0d6c17f06a0e6d4436422e0ad29b882c40697d2",
-                "sha256:b571bf5341ba8c6bc02e0baeaf3b061ab993bf372d982ae509807e7f112554e9",
-                "sha256:b8194fb8e50d556d5849753de991d390c5a1edeeba50f68e3a9253fbd8bf8ccd",
-                "sha256:b87eb6fc9e1bb8f98892a2458781348fa37e6925f35bb6ceb9d4afd54ba36c73",
-                "sha256:bbb5cc845a0292e0c520656d19d7ce40e18d0e19b22cb3e0409135a575bf79fc",
-                "sha256:be945402e03de47ba1872cd5236395e0f4ad635526185a930735f66710e1bd3f",
-                "sha256:bf13d564d310c156d1c8e53877baf2993fb3073b2fc9f69790ca6a732eb4bfea",
-                "sha256:cf60dd2696b457b710dd40bf17ad269d5f5457b96442f7f85722bdb16fa6c899",
-                "sha256:d1ba00ae33be84066cfbe7361d4e04dec78445b2b88bdb734d0d1cbab916025a",
-                "sha256:d39fc4817fd67b3915256af5dda75fd4ee10621a3d484524487e33416c6f3543",
-                "sha256:d766a4f0e5aa1ba056ec3496243150698dc0481902e2b8559314368717be82b1",
-                "sha256:dbf364b4c5e7bae9250528167dfe40219b62e2d573c854d74be213e1e52069f7",
-                "sha256:dd19608788b50eed889e13a5d71d832edc34fc9dfce606f66e8f9f917eef910d",
-                "sha256:e013b07ba1c748dacc2a80e69a46286ff145935f260eb8c72df7185bf048f502",
-                "sha256:e5d2b9be5b0693cf21eb4ce0ec8d211efb43966f6657807f6859aab3814f946b",
-                "sha256:e5ff52d790c7e1628241ffbcaeb33e07d14b007b6eb00a19320c7b8a7024c040",
-                "sha256:e75a2ad7b647fd8046d58c3132d7eaf31b12d8a53c0e4b21fa9c4d23d6ee6d3c",
-                "sha256:e7ac22a0bb2c7c49f441f7a6d46c9c80d96e56f5a8bc6972529ed43c8b694e27",
-                "sha256:ed2144b8a78f9d94d9515963ed273d620e07846acd5d4b0a642d4849e8d91a0c",
-                "sha256:f017a61399f13aa6d1039f75cd467be388d157cd81f1a119b9d9a68ba6f2830d",
-                "sha256:f1d8a2a57b47142b10374902777e798784abf400a004b14f1b0b9eaf1e528ba4",
-                "sha256:f2d32f95922927186c6dbc8bc60df0d186b6edb828d299ab10898ef3f40052fe",
-                "sha256:f319bae0321bc838e205bf9e5bc28f0a3165f30c203b610f17ab5552cff90323",
-                "sha256:f3c38e4e5ccbdc9198aecc766cedbb134b2d89bf64533973678dfcf07effd883",
-                "sha256:f9983d01d7705b2d1f7a95e10bbe4091fabc03a46881a256c2787637b087003f",
-                "sha256:fa260de59dfb143af06dcf30c2be0b200bed2a73737a8a59248fcb9fa601ef0f"
+                "sha256:00f2e2f2e37f47e5f54423aeefd6c32a7dbcedc033fcd3928a4f4948e8b96af7",
+                "sha256:05364b9cc82f138cc86128dc4e2e1251c2981a2218bfcd556fe6b0fbaa3501be",
+                "sha256:0774df1e093acb6c9e4d58bce7f86656aeed6c132a16e2337692c12786b32404",
+                "sha256:07a989c867986c2a75f158f03fdb413128aad29aca9d4dbce5fc755672d96f11",
+                "sha256:0bdc8bf760459a4a4187b452213e04d039990211f98644c7292adf1e471162b5",
+                "sha256:0e49824808d4375ede9dd84e9961a59c47f9113039f1a525e6be170aa4f5c34d",
+                "sha256:145b07bea229821d51811bf15eeab346c236d523838eda395ea969d120d13347",
+                "sha256:159b81df53a5fcbc7d45dae3adad554fdbde9829a994e15227b3f9d816d00b36",
+                "sha256:1676628065a498943bd3f64f099bb573e08cf1bc6088bbe33cf4424e0876f4b3",
+                "sha256:1aec326ed237e5880bfe69ad41616d333712c7937bcefc1343145e972938f9b3",
+                "sha256:1e1448bb72b387755e1ff3ef1268a06617afd94188164960dba8d0245a46004b",
+                "sha256:1efa4166ba75ccefd647f2d78b64f53f14fb82622bc94c5a5cb0a622f50f1c9e",
+                "sha256:26a4636ddb666971345541b59899e969f3b301143dd86b0ddbb570bd591f1e85",
+                "sha256:2bd0a0a5054be160777a7920b731a0570284db5142abaaf81bcbb282b8d99279",
+                "sha256:2c08b05ee8d7861e45dc5a2cc4195c8c66dca5ac613144eb6ebeaff2d502e73d",
+                "sha256:2db10dedeb619a771ef0e2949ccba7b75e33905de959c2643a4607bef2f3fb3a",
+                "sha256:2f9bc608fbafaee40eb60a9a53dbfb90f53cc66d3d32c2849dc27cf5638a21e3",
+                "sha256:34759ee2c65362163699cc917bdb2a54114dd06d19bab860725f94ef45a3d9b7",
+                "sha256:3da9b771c98977a13fbc3830f6caa85cae6c9c83911d24cb2d218e9394259c57",
+                "sha256:3f5673888d3676d0a745c3d0e16da338c5eea300cb1f4ada9c872981265e76d8",
+                "sha256:4000a31c34932e7e4fa0381a3d6deb43dc0c8f458e3e7ea6502e6238e10be625",
+                "sha256:43ff5033d657cd51f83015c3b7a443287250dc14e69910577c3e03bd2e06f27b",
+                "sha256:46d532db4e5ff3979ce47d18e2fe8ecad283eeb7367726da0e5ef88e4fe64740",
+                "sha256:496948261eaac5ac9cf43f5d0a9f6eb7a6d4cb3bedb2c5d294138142f5c18f2a",
+                "sha256:4c26c2396674816deaeae7ded0e2b42c26537280f8fe313335858ffff35019be",
+                "sha256:5040536cf9b13fb033f76bcb5e1e5cb3b57c4807fef37db9e0ed129c6a094257",
+                "sha256:546e537d9e24efc765c9c891328f30f826e3e4808e31f5d0f87c4ba12bbd1622",
+                "sha256:5e818796f71702d7a13e50c70de2a1924f729228580bcba1607cccf32eea46e6",
+                "sha256:5feb7f2c3e6ea94d3b877def0270dff0947b8d8c04cfa34a17be0a4dc1836879",
+                "sha256:641988828bc18a6368fe72355df5f1703e44411adbe49bba5644b941ce6f2e3a",
+                "sha256:670a13249b957bb9050fab12d86acef7bf8f6a879b9d1a883799276e0d4c674a",
+                "sha256:6782a12bf76fa61ad9350d5a6ef5f3f020b57f5e6305cbc663803f2ebd0f270a",
+                "sha256:684ca9f58119b8e26bef860db33524ae0365601492e86ba0b71d513f525e7050",
+                "sha256:6e6c86888fd076d9e0fe848af0a2142bf606044dc5ceee0aa9eddb56e26895a0",
+                "sha256:726f32ee3713f7359696331a18daf0c3b3a70bb0ae71141b9d3c52be7c595e32",
+                "sha256:76090fab50610798cc05241bf83b603477c40ee87acd358b66196ab0ca44ffa1",
+                "sha256:8165584ddedb49204c4e18da083913bdf6a982bfb558632a79bdaadcdafd0d48",
+                "sha256:820157de3a589e992689ffcda8639fbabb313b323d26388d02e154164c57b07f",
+                "sha256:8369a7c8ef66bded2b6484053749ff220dbf83cba84f3398c84c51a6f748a008",
+                "sha256:86a323a275e9e44cdf228af9b71c5030861d4d2610886ab920d9945672a81223",
+                "sha256:876cbfd0b09ce09d81585d266c07a32657beb3eaec896f39484b631555be0fe2",
+                "sha256:8966a821e2083c74d88cca5b7dcccc0a3a888a596a04c0b9668a891de3a0cc53",
+                "sha256:8ab4a51cb39dc1933ba627e0875046d150e88478dbe22ce145a68393e9652975",
+                "sha256:8e1a26e7e50076e35f7afafde570ca2b4d7900a491174ca357d29dece5aacee7",
+                "sha256:94316e13f0981cbbba132c1f9f365cac1d26716aaac130866ca812006f662199",
+                "sha256:9a990f6510b3292686713bfef26d0049cd63b9c7bb17e0864f133cbfd2e6167f",
+                "sha256:9fe449ee461a3b0c7105690419d0b0aba1232f4ff6d120a9e241e58a556733f7",
+                "sha256:a886d531373a1f6ff9fad2a2ba4a045b68467b779ae729ee0b3b10ac20033b27",
+                "sha256:ab9b09a2349f58e73f8ebc06fac546dd623e23b063e5398343c5270072e3201c",
+                "sha256:b039ffddc99ad65d5078ef300e0c7eed08c270dc26570440e3ef18beb816c1ca",
+                "sha256:b069938961dfad881dc2f8d02b47645cd2f455d3809ba92a8a687bf513839787",
+                "sha256:b99058eef42e6a8dcd135afb068b3d53aff3921ce699e127602efff9956457a9",
+                "sha256:bd8ec21e1443fd7a447881332f7ce9d35b8fbd2849e761bb290b584535636b0a",
+                "sha256:bf8111cddd0f2b54d34e96613e7fbdd59a673f0cf5574b61134ae75b6f5a33b8",
+                "sha256:c9392773cffeb8d7e042a7b15b82a414011e9d2b5fdbbd3f7e6a6b17d5e21b20",
+                "sha256:cb86337a4fcdd0e598ff2caeb513ac604d2f3da6d53df2c8e368e07ee38e277d",
+                "sha256:da23ce9a3d356d0affe9c7036030b5c8f14556bd970c9b224f9c8205505e3b99",
+                "sha256:dc67994df9bcd7e0150a47ef41278b9e0a0ea187caba72414b71dc590b99a108",
+                "sha256:de77c3ba8bb686d1c411e78ee1b97e6e0b963fb98b1637658dd9ad2c875cf9d7",
+                "sha256:e2f6fe3654468d061942591aef56686131335b7a8325684eda85dacdf311356c",
+                "sha256:e6ea7dba4e92926b7b5f0990634b78ea02f208d04af520c73a7c876d5a8d36cb",
+                "sha256:e6fcbbd35a96192d042c691c9e0c49ef54bd7ed865846a3c9d624c30bb67ce46",
+                "sha256:ea561010914ec1c26ab4188aef8b1567272ef6de096312716f90e5baa79ef8ca",
+                "sha256:eacd2de0d30871eff893bab0b67840a96445edcb3c8fd915e6b11ac4b2f3fa6d",
+                "sha256:ec455eedf3ba0bbdf8f5a570012617eb305c63cb9f03428d39bf544cb2b94837",
+                "sha256:ef2f22795a7aca99fc3c84393a55a53dd18ab8c93fb431004e4d8f0774150f54",
+                "sha256:fd51355ab8a372d89fb0e6a31719e825cf8df8b6724bee942fb5b92c3f016ba3"
             ],
             "markers": "python_version >= '3.9'",
-            "version": "==7.8.0"
+            "version": "==7.8.2"
         },
         "docutils": {
             "hashes": [
@@ -232,11 +245,11 @@
         },
         "exceptiongroup": {
             "hashes": [
-                "sha256:3111b9d131c238bec2f8f516e123e14ba243563fb135d3fe885990585aa7795b",
-                "sha256:47c2edf7c6738fafb49fd34290706d1a1a2f4d1c6df275526b62cbb4aa5393cc"
+                "sha256:4d111e6e0c13d0644cad6ddaa7ed0261a0b36971f6d23e7ec9b4b9097da78a10",
+                "sha256:b241f5885f560bc56a59ee63ca4c6a8bfa46ae4ad651af316d4e81817bb9fd88"
             ],
             "markers": "python_version < '3.11'",
-            "version": "==1.2.2"
+            "version": "==1.3.0"
         },
         "id": {
             "hashes": [
@@ -256,11 +269,11 @@
         },
         "importlib-metadata": {
             "hashes": [
-                "sha256:02a89390c1e15fdfdc0d7c6b25cb3e62650d0494005c97d6f148bf5b9787525e",
-                "sha256:310b41d755445d74569f993ccfc22838295d9fe005425094fad953d7f15c8580"
+                "sha256:d13b81ad223b890aa16c5471f2ac3056cf76c5f10f82d6f9292f0b415f389000",
+                "sha256:e5dd1551894c77868a30651cef00984d50e1002d06942a7101d34870c5f02afd"
             ],
             "markers": "python_version < '3.12'",
-            "version": "==8.6.1"
+            "version": "==8.7.0"
         },
         "iniconfig": {
             "hashes": [
@@ -320,11 +333,11 @@
         },
         "more-itertools": {
             "hashes": [
-                "sha256:2cd7fad1009c31cc9fb6a035108509e6547547a7a738374f10bd49a09eb3ee3b",
-                "sha256:6eb054cb4b6db1473f6e15fcc676a08e4732548acd47c708f0e179c2c7c01e89"
+                "sha256:9fddd5403be01a94b204faadcff459ec3568cf110265d3c54323e1e866ad29d3",
+                "sha256:d43980384673cb07d2f7d2d918c616b30c659c089ee23953f601d6609c67510e"
             ],
             "markers": "python_version >= '3.9'",
-            "version": "==10.6.0"
+            "version": "==10.7.0"
         },
         "nh3": {
             "hashes": [
@@ -358,19 +371,19 @@
         },
         "packaging": {
             "hashes": [
-                "sha256:09abb1bccd265c01f4a3aa3f7a7db064b36514d2cba19a2f694fe6150451a759",
-                "sha256:c228a6dc5e932d346bc5739379109d49e8853dd8223571c7c5b55260edc0b97f"
+                "sha256:29572ef2b1f17581046b3a2227d5c611fb25ec70ca1ba8554b24b0e69331a484",
+                "sha256:d443872c98d677bf60f6a1f2f8c1cb748e8fe762d2bf9d3148b5599295b0fc4f"
             ],
             "markers": "python_version >= '3.8'",
-            "version": "==24.2"
+            "version": "==25.0"
         },
         "pluggy": {
             "hashes": [
-                "sha256:2cffa88e94fdc978c4c574f15f9e59b7f4201d439195c3715ca9e2486f1d0cf1",
-                "sha256:44e1ad92c8ca002de6377e165f3e0f1be63266ab4d554740532335b9d75ea669"
+                "sha256:7dcc130b76258d33b90f61b658791dede3486c3e6bfb003ee5c9bfb396dd22f3",
+                "sha256:e920276dd6813095e9377c0bc5566d94c932c33b27a3e3945d8389c374dd4746"
             ],
-            "markers": "python_version >= '3.8'",
-            "version": "==1.5.0"
+            "markers": "python_version >= '3.9'",
+            "version": "==1.6.0"
         },
         "pygments": {
             "hashes": [
@@ -466,28 +479,28 @@
         },
         "ruff": {
             "hashes": [
-                "sha256:0e9365a7dff9b93af933dab8aebce53b72d8f815e131796268709890b4a83270",
-                "sha256:126b1bf13154aa18ae2d6c3c5efe144ec14b97c60844cfa6eb960c2a05188222",
-                "sha256:193e6fac6eb60cc97b9f728e953c21cc38a20077ed64f912e9d62b97487f3f2d",
-                "sha256:3f171605f65f4fc49c87f41b456e882cd0c89e4ac9d58e149a2b07930e1d466f",
-                "sha256:51a6494209cacca79e121e9b244dc30d3414dac8cc5afb93f852173a2ecfc906",
-                "sha256:5a9fa1c69c7815e39fcfb3646bbfd7f528fa8e2d4bebdcf4c2bd0fa037a255fb",
-                "sha256:5d94bb1cc2fc94a769b0eb975344f1b1f3d294da1da9ddbb5a77665feb3a3019",
-                "sha256:7a37ca937e307ea18156e775a6ac6e02f34b99e8c23fe63c1996185a4efe0751",
-                "sha256:7af4e5f69b7c138be8dcffa5b4a061bf6ba6a3301f632a6bce25d45daff9bc99",
-                "sha256:8c1747d903447d45ca3d40c794d1a56458c51e5cc1bc77b7b64bd2cf0b1626cc",
-                "sha256:995071203d0fe2183fc7a268766fd7603afb9996785f086b0d76edee8755c896",
-                "sha256:d435db6b9b93d02934cf61ef332e66af82da6d8c69aefdea5994c89997c7a0fc",
-                "sha256:d9f4a761ecbde448a2d3e12fb398647c7f0bf526dbc354a643ec505965824ed2",
-                "sha256:e8806daaf9dfa881a0ed603f8a0e364e4f11b6ed461b56cae2b1c0cab0645304",
-                "sha256:ebf99ea9af918878e6ce42098981fc8c1db3850fef2f1ada69fb1dcdb0f8e79e",
-                "sha256:edad2eac42279df12e176564a23fc6f4aaeeb09abba840627780b1bb11a9d223",
-                "sha256:f103a848be9ff379fc19b5d656c1f911d0a0b4e3e0424f9532ececf319a4296e",
-                "sha256:f45bd2fb1a56a5a85fae3b95add03fb185a0b30cf47f5edc92aa0355ca1d7407"
+                "sha256:1adcb9a18802268aaa891ffb67b1c94cd70578f126637118e8099b8e4adcf112",
+                "sha256:1b5ab797fcc09121ed82e9b12b6f27e34859e4227080a42d090881be888755d4",
+                "sha256:6224076c344a7694c6fbbb70d4f2a7b730f6d47d2a9dc1e7f9d9bb583faf390b",
+                "sha256:64ac6f885e3ecb2fdbb71de2701d4e34526651f1e8503af8fb30d4915a3fe345",
+                "sha256:6c51f136c0364ab1b774767aa8b86331bd8e9d414e2d107db7a2189f35ea1f7b",
+                "sha256:748b4bb245f11e91a04a4ff0f96e386711df0a30412b9fe0c74d5bdc0e4a531f",
+                "sha256:7774173cc7c1980e6bf67569ebb7085989a78a103922fb83ef3dfe230cd0687d",
+                "sha256:7885d9a5e4c77b24e8c88aba8c80be9255fa22ab326019dac2356cff42089fc6",
+                "sha256:882821fcdf7ae8db7a951df1903d9cb032bbe838852e5fc3c2b6c3ab54e39875",
+                "sha256:9263f9e5aa4ff1dec765e99810f1cc53f0c868c5329b69f13845f699fe74f639",
+                "sha256:9924e5ae54125ed8958a4f7de320dab7380f6e9fa3195e3dc3b137c6842a0092",
+                "sha256:99c28505ecbaeb6594701a74e395b187ee083ee26478c1a795d35084d53ebd81",
+                "sha256:a97c9babe1d4081037a90289986925726b802d180cca784ac8da2bbbc335f709",
+                "sha256:c8a93276393d91e952f790148eb226658dd275cddfde96c6ca304873f11d2ae4",
+                "sha256:d6e333dbe2e6ae84cdedefa943dfd6434753ad321764fd937eef9d6b62022bcd",
+                "sha256:d8c4ddcbe8a19f59f57fd814b8b117d4fcea9bee7c0492e6cf5fdc22cfa563c8",
+                "sha256:dcec2d50756463d9df075a26a85a6affbc1b0148873da3997286caf1ce03cae1",
+                "sha256:e231ff3132c1119ece836487a02785f099a43992b95c2f62847d29bace3c75ac"
             ],
             "index": "pypi",
             "markers": "python_version >= '3.7'",
-            "version": "==0.11.4"
+            "version": "==0.11.11"
         },
         "tomli": {
             "hashes": [
@@ -546,19 +559,20 @@
         },
         "typing-extensions": {
             "hashes": [
-                "sha256:4b6cf02909eb5495cfbc3f6e8fd49217e6cc7944e145cdda8caa3734777f9e69",
-                "sha256:98795af00fb9640edec5b8e31fc647597b4691f099ad75f469a2616be1a76dff"
+                "sha256:a439e7c04b49fec3e5d3e2beaa21755cadbbdc391694e28ccdd36ca4a1408f8c",
+                "sha256:e6c81219bd689f51865d9e372991c540bda33a0379d5573cddb9a3a23f7caaef"
             ],
-            "markers": "python_version < '3.11'",
-            "version": "==4.13.1"
+            "index": "pypi",
+            "markers": "python_version >= '3.8'",
+            "version": "==4.13.2"
         },
         "urllib3": {
             "hashes": [
-                "sha256:1cee9ad369867bfdbbb48b7dd50374c0967a0bb7710050facf0dd6911440e3df",
-                "sha256:f8c5449b3cf0861679ce7e0503c7b44b5ec981bec0d1d3795a07f1ba96f0204d"
+                "sha256:414bc6535b787febd7567804cc015fee39daab8ad86268f1310a9250697de466",
+                "sha256:4e16665048960a0900c702d4a66415956a584919c03361cac9f1df5c5dd7e813"
             ],
             "markers": "python_version >= '3.9'",
-            "version": "==2.3.0"
+            "version": "==2.4.0"
         },
         "zipp": {
             "hashes": [

--- a/README.md
+++ b/README.md
@@ -25,8 +25,8 @@ import classyclick
 class Hello:
     """Simple program that greets NAME for a total of COUNT times."""
 
-    name: str = classyclick.option(prompt='Your name', help='The person to greet.')
-    count: int = classyclick.option(default=1, help='Number of greetings.')
+    name: str = classyclick.Option(prompt='Your name', help='The person to greet.')
+    count: int = classyclick.Option(default=1, help='Number of greetings.')
 
     def __call__(self):
         for _ in range(self.count):
@@ -86,8 +86,8 @@ import classyclick
 class Hello:
     """Simple program that greets NAME for a total of COUNT times."""
 
-    name: str = classyclick.option(prompt='Your name', help='The person to greet.')
-    count: int = classyclick.option(default=1, help='Number of greetings.')
+    name: str = classyclick.Option(prompt='Your name', help='The person to greet.')
+    count: int = classyclick.Option(default=1, help='Number of greetings.')
 
     def __call__(self):
         self.greet()
@@ -132,14 +132,14 @@ Same as `click.command`, you can choose a command `name` or allow it to derive i
 
 It will also forward class `__doc__` to click to be used as description if not specified as keyword arg.
 
-### classyclick.option
+### classyclick.Option
 
 Instead of the decorator approach, this is more like [Django's models](https://docs.djangoproject.com/en/dev/topics/db/models/) to take advantage of how parameters are enumerated.
 
 As you noticed from the example, there's no need to specify an option parameter name:
 
 ```
-count: int = classyclick.option(default=1, help='Number of greetings.')
+count: int = classyclick.Option(default=1, help='Number of greetings.')
 ```
 
 `classyclick` makes use of the field names to infer a default (`--count` in example).
@@ -147,40 +147,40 @@ count: int = classyclick.option(default=1, help='Number of greetings.')
 To add a short version *on top of it*:
 
 ```
-count: int = classyclick.option('-c', default=1, help='Number of greetings.')
+count: int = classyclick.Option('-c', default=1, help='Number of greetings.')
 ```
 
 And to only include the short, you can use the only keyword argument that is not forwarded to [@click.option](https://click.palletsprojects.com/en/stable/api/#click.option): `default_parameter`
 
 ```
-count: int = classyclick.option('-c', default_parameter=False, default=1, help='Number of greetings.')
+count: int = classyclick.Option('-c', default_parameter=False, default=1, help='Number of greetings.')
 ```
 
-`classyclick.option` also infers **type** from type hints, then passed to `click.option`.
+`classyclick.Option` also infers **type** from type hints, then passed to `click.option`.
 
 ```python
 # The resulting click.option will use type=Path
-output: Path = classyclick.option()
+output: Path = classyclick.Option()
 
 # You can still override it and mix things if you want ¯\_(ツ)_/¯
-other_output: Any = classyclick.option(type=str)
+other_output: Any = classyclick.Option(type=str)
 ```
 
 When type is `bool`, it will set `is_flag=True` as well. If for some reason you don't want that, it can still be overriden.
 
 ```python
 # This results in click.option('--verbose', type=bool, is_flag=True)
-verbose: bool = classyclick.option()
+verbose: bool = classyclick.Option()
 
 # As mentioned, it can always be overriden if you need the weird behavior of a non-flag bool option...
-weird: bool = classyclick.option(is_flag=False)
+weird: bool = classyclick.Option(is_flag=False)
 ```
 
-### classyclick.argument
+### classyclick.Argument
 
-Similar to `classyclick.option`, this is mostly wrapping [@click.argument](https://click.palletsprojects.com/en/stable/api/#click.argument) so it can be used in fields.
+Similar to `classyclick.Option`, this is mostly wrapping [@click.argument](https://click.palletsprojects.com/en/stable/api/#click.argument) so it can be used in fields.
 
-Argument name is inferred from the field name and, same as `classyclick.option`, type from field.type.  
+Argument name is inferred from the field name and, same as `classyclick.Option`, type from field.type.  
 Again, type can be overriden, however not argument name as it has to match the property. For display purposes, you can use `metavar=`.
 
 ```python
@@ -188,7 +188,7 @@ Again, type can be overriden, however not argument name as it has to match the p
 class Next:
     """Output the next number."""
 
-    your_number: int = classyclick.argument()
+    your_number: int = classyclick.Argument()
 
     def __call__(self):
         click.echo(self.your_number + 1)
@@ -207,7 +207,7 @@ $ ./cli_four.py 5
 6
 ```
 
-### classyclick.context
+### classyclick.Context
 
 Like [@click.pass_context](https://click.palletsprojects.com/en/stable/api/#click.pass_context), this exposes `click.Context` in a command property.
 
@@ -216,14 +216,14 @@ Like [@click.pass_context](https://click.palletsprojects.com/en/stable/api/#clic
 class Next:
     """Output the next number."""
 
-    your_number: int = classyclick.argument()
-    the_context: Any = classyclick.context()
+    your_number: int = classyclick.Argument()
+    the_context: Any = classyclick.Context()
 
     def __call__(self):
         click.echo(self.your_number + self.the_context.obj.step_number)
 ```
 
-### classyclick.context_obj
+### classyclick.ContextObj
 
 Like [@click.pass_obj](https://click.palletsprojects.com/en/stable/api/#click.pass_obj), this assigns `click.Context.obj` to a command property, when you only want the user data rather than the whole context.
 
@@ -232,14 +232,14 @@ Like [@click.pass_obj](https://click.palletsprojects.com/en/stable/api/#click.pa
 class Next:
     """Output the next number."""
 
-    your_number: int = classyclick.argument()
-    the_context: Any = classyclick.context_obj()
+    your_number: int = classyclick.Argument()
+    the_context: Any = classyclick.ContextObj()
 
     def __call__(self):
         click.echo(self.your_number + self.the_context.step_number)
 ```
 
-### classyclick.context_meta
+### classyclick.ContextMeta
 
 Like [@click.pass_meta_key](https://click.palletsprojects.com/en/stable/api/#click.decorators.pass_meta_key), this assigns `click.Context.meta[KEY]` to a command property, without handling the whole context.
 
@@ -248,8 +248,8 @@ Like [@click.pass_meta_key](https://click.palletsprojects.com/en/stable/api/#cli
 class Next:
     """Output the next number."""
 
-    your_number: int = classyclick.argument()
-    step_number: int = classyclick.context_meta("step_number")
+    your_number: int = classyclick.Argument()
+    step_number: int = classyclick.ContextMeta("step_number")
 
     def __call__(self):
         click.echo(self.your_number + self.step_number)

--- a/classyclick/__init__.py
+++ b/classyclick/__init__.py
@@ -1,5 +1,30 @@
 from .__version__ import __version__, version
 from .command import command
-from .fields import argument, context, context_meta, context_obj, option
+from .fields import (
+    Argument,
+    Context,
+    ContextMeta,
+    ContextObj,
+    Option,
+    argument,
+    context,
+    context_meta,
+    context_obj,
+    option,
+)
 
-__all__ = ['__version__', 'version', 'command', 'option', 'argument', 'context_obj', 'context', 'context_meta']
+__all__ = [
+    '__version__',
+    'version',
+    'command',
+    'option',
+    'argument',
+    'context_obj',
+    'context',
+    'context_meta',
+    'Argument',
+    'Context',
+    'ContextMeta',
+    'ContextObj',
+    'Option',
+]

--- a/classyclick/command.py
+++ b/classyclick/command.py
@@ -5,7 +5,7 @@ if TYPE_CHECKING:
     from click import Command
 
 from . import utils
-from .fields import ClassyField
+from .fields import _Field
 
 T = TypeVar('T')
 
@@ -47,7 +47,7 @@ def command(group=None, **click_kwargs) -> Callable[[T], Union[T, Clickable]]:
         # apply options
         # apply in reverse order to match click's behavior - it DOES MATTER when multiple click.argument
         for field in fields(kls)[::-1]:
-            if isinstance(field.default, ClassyField):
+            if isinstance(field.default, _Field):
                 func = field.default(func, field)
 
         command = group.command(**click_kwargs)(func)
@@ -64,6 +64,6 @@ def _strictly_typed_dataclass(kls):
     for name, val in kls.__dict__.items():
         if name.startswith('__'):
             continue
-        if name not in annotations and isinstance(val, ClassyField):
+        if name not in annotations and isinstance(val, _Field):
             raise TypeError(f"{kls.__module__}.{kls.__qualname__} is missing type for classy field '{name}'")
     return dataclass(kls)

--- a/classyclick/fields.py
+++ b/classyclick/fields.py
@@ -10,7 +10,7 @@ if TYPE_CHECKING:
 from . import utils
 
 
-def option(*param_decls: str, default_parameter=True, **attrs: Any) -> 'ClassyOption':
+def option(*param_decls: str, default_parameter=True, **attrs: Any) -> 'Option':
     """
     Attaches an option to the class field.
 
@@ -23,10 +23,10 @@ def option(*param_decls: str, default_parameter=True, **attrs: Any) -> 'ClassyOp
     * Type based type hint, if none is specified
     * No "name" is allowed, as that's already infered from field.name - that means the only positional arguments allowed are the ones that start with "-"
     """
-    return ClassyOption(param_decls=param_decls, default_parameter=default_parameter, attrs=attrs)
+    return Option(param_decls=param_decls, default_parameter=default_parameter, attrs=attrs)
 
 
-def argument(*, type=None, **attrs: Any) -> 'ClassyArgument':
+def argument(*, type=None, **attrs: Any) -> 'Argument':
     """
     Attaches an argument to the class field.
 
@@ -35,21 +35,21 @@ def argument(*, type=None, **attrs: Any) -> 'ClassyArgument':
     """
     if type is not None:
         attrs['type'] = type
-    return ClassyArgument(attrs=attrs)
+    return Argument(attrs=attrs)
 
 
-def context() -> 'ClassyContext':
+def context() -> 'Context':
     """
     ...
     """
-    return ClassyContext(attrs=None)
+    return Context(attrs=None)
 
 
-def context_obj() -> 'ClassyContextObj':
+def context_obj() -> 'ContextObj':
     """
     ...
     """
-    return ClassyContextObj(attrs=None)
+    return ContextObj(attrs=None)
 
 
 def context_meta(key: str, **attrs: Any) -> 'ClassyContextMeta':

--- a/classyclick/fields.py
+++ b/classyclick/fields.py
@@ -52,15 +52,15 @@ def context_obj() -> 'ContextObj':
     return ContextObj(attrs=None)
 
 
-def context_meta(key: str, **attrs: Any) -> 'ClassyContextMeta':
+def context_meta(key: str, **attrs: Any) -> 'ContextMeta':
     """
     ...
     """
-    return ClassyContextMeta(key=key, attrs=attrs)
+    return ContextMeta(key=key, attrs=attrs)
 
 
 @dataclass(frozen=True)
-class ClassyField:
+class _Field:
     attrs: dict[Any]
 
     def infer_type(self, field: 'Field'):
@@ -83,7 +83,7 @@ class ClassyField:
 
 
 @dataclass(frozen=True)
-class ClassyArgument(ClassyField):
+class Argument(_Field):
     def __call__(self, command: 'Command', field: 'Field'):
         self.infer_type(field)
 
@@ -91,7 +91,7 @@ class ClassyArgument(ClassyField):
 
 
 @dataclass(frozen=True)
-class ClassyOption(ClassyField):
+class Option(_Field):
     param_decls: list[str]
     default_parameter: bool
 
@@ -120,7 +120,7 @@ class ClassyOption(ClassyField):
 
 
 @dataclass(frozen=True)
-class ClassyContext(ClassyField):
+class Context(_Field):
     def store_field_name(self, command: 'Command', field: 'Field'):
         if not hasattr(command, '__classy_context__'):
             command.__classy_context__ = []  # type: ignore
@@ -132,14 +132,14 @@ class ClassyContext(ClassyField):
 
 
 @dataclass(frozen=True)
-class ClassyContextObj(ClassyContext):
+class ContextObj(Context):
     def __call__(self, command: 'Command', field: 'Field'):
         self.store_field_name(command, field)
         return self.click.pass_obj(command)
 
 
 @dataclass(frozen=True)
-class ClassyContextMeta(ClassyContext):
+class ContextMeta(Context):
     key: str
 
     def __call__(self, command: 'Command', field: 'Field'):

--- a/classyclick/fields.py
+++ b/classyclick/fields.py
@@ -1,6 +1,8 @@
 from dataclasses import dataclass
 from typing import TYPE_CHECKING, Any, get_args, get_origin
 
+from typing_extensions import deprecated
+
 if TYPE_CHECKING:
     from dataclasses import Field
 
@@ -10,6 +12,7 @@ if TYPE_CHECKING:
 from . import utils
 
 
+@deprecated('use Option instead')
 def option(*param_decls: str, default_parameter=True, **attrs: Any) -> 'Option':
     """
     Attaches an option to the class field.
@@ -26,6 +29,7 @@ def option(*param_decls: str, default_parameter=True, **attrs: Any) -> 'Option':
     return Option(param_decls=param_decls, default_parameter=default_parameter, attrs=attrs)
 
 
+@deprecated('use Aption instead')
 def argument(*, type=None, **attrs: Any) -> 'Argument':
     """
     Attaches an argument to the class field.
@@ -38,23 +42,29 @@ def argument(*, type=None, **attrs: Any) -> 'Argument':
     return Argument(attrs=attrs)
 
 
+@deprecated('use Context instead')
 def context() -> 'Context':
     """
-    ...
+    Like :meth:`click.pass_context` (see https://click.palletsprojects.com/en/stable/api/#click.pass_context),
+    this exposes `click.Context` in a command property.
     """
     return Context(attrs=None)
 
 
+@deprecated('use ContextObj instead')
 def context_obj() -> 'ContextObj':
     """
-    ...
+    Like :meth:`click.pass_obj` (see https://click.palletsprojects.com/en/stable/api/#click.pass_obj),
+    this assigns `click.Context.obj` to a command property, when you only want the user data rather than the whole context.
     """
     return ContextObj(attrs=None)
 
 
+@deprecated('use ContextMeta instead')
 def context_meta(key: str, **attrs: Any) -> 'ContextMeta':
     """
-    ...
+    Like :meth:`click.pass_meta_key` (see https://click.palletsprojects.com/en/stable/api/#click.decorators.pass_meta_key),
+    this assigns `click.Context.meta[KEY]` to a command property, without handling the whole context.
     """
     return ContextMeta(key=key, attrs=attrs)
 

--- a/classyclick/fields.py
+++ b/classyclick/fields.py
@@ -88,7 +88,6 @@ class _Field:
 
     def __call__(self, command: 'Command', field: 'Field') -> 'Command':
         """To be implemented in subclasses"""
-        return command
 
 
 class Argument(_Field):

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -22,7 +22,7 @@ classifiers = [
     "Programming Language :: Python :: 3.11",
     "Programming Language :: Python :: 3.12",
 ]
-dependencies = ["click>=7"]
+dependencies = ["click>=7", "typing-extensions>=4.12.2"]
 
 [project.urls]
 Homepage = "https://github.com/fopina/classyclick"

--- a/tests/cli_four.py
+++ b/tests/cli_four.py
@@ -13,7 +13,7 @@ import classyclick
 class Next:
     """Output the next number."""
 
-    your_number: int = classyclick.argument()
+    your_number: int = classyclick.Argument()
 
     def __call__(self):
         click.echo(self.your_number + 1)

--- a/tests/cli_one.py
+++ b/tests/cli_one.py
@@ -13,7 +13,7 @@ import classyclick
 class Hello:
     """Simple program that greets NAME for a total of COUNT times."""
 
-    name: str = classyclick.option(prompt='Your name', help='The person to greet.')
+    name: str = classyclick.Option(prompt='Your name', help='The person to greet.')
     count: int = classyclick.option('-c', default=1, help='Number of greetings.')
 
     def __call__(self):

--- a/tests/cli_one.py
+++ b/tests/cli_one.py
@@ -14,7 +14,7 @@ class Hello:
     """Simple program that greets NAME for a total of COUNT times."""
 
     name: str = classyclick.Option(prompt='Your name', help='The person to greet.')
-    count: int = classyclick.option('-c', default=1, help='Number of greetings.')
+    count: int = classyclick.Option('-c', default=1, help='Number of greetings.')
 
     def __call__(self):
         for _ in range(self.count):

--- a/tests/cli_two.py
+++ b/tests/cli_two.py
@@ -13,8 +13,8 @@ import classyclick
 class Hello:
     """Simple program that DOES NOT greet NAME for a total of COUNT times BECAUSE OF MISSING TYPES."""
 
-    name = classyclick.option(prompt='Your name', help='The person to greet.')
-    count = classyclick.option('-c', type=int, default=1, help='Number of greetings.')
+    name = classyclick.Option(prompt='Your name', help='The person to greet.')
+    count = classyclick.Option('-c', type=int, default=1, help='Number of greetings.')
 
     def __call__(self):
         for _ in range(self.count):

--- a/tests/test_clis.py
+++ b/tests/test_clis.py
@@ -22,7 +22,7 @@ class Test(TestCase):
             from .cli_two import Hello
 
             # no-op until "ruff format" gets pragma support (like # fmt: off)
-            Hello
+            Hello.click()
 
         self.assertRaisesRegex(TypeError, "tests.cli_two.Hello is missing type for classy field 'name'", _a)
 

--- a/tests/test_command_argument.py
+++ b/tests/test_command_argument.py
@@ -8,7 +8,7 @@ class Test(BaseCase):
     def test_argument(self):
         @classyclick.command()
         class Hello:
-            name: str = classyclick.argument()
+            name: str = classyclick.Argument()
 
             def __call__(self):
                 print(f'Hello, {self.name}')
@@ -39,7 +39,7 @@ Options:
     def test_metavar(self):
         @classyclick.command()
         class Hello:
-            name: str = classyclick.argument(metavar='YOUR_NAME')
+            name: str = classyclick.Argument(metavar='YOUR_NAME')
 
             def __call__(self):
                 print(f'Hello, {self.name}')
@@ -65,9 +65,9 @@ Options:
     def test_type_inference(self):
         @classyclick.command()
         class Sum:
-            a: int = classyclick.argument()
+            a: int = classyclick.Argument()
             # bad type hint but the explicit one supersedes, so test still passes
-            b: str = classyclick.argument(type=int)
+            b: str = classyclick.Argument(type=int)
 
             def __call__(self):
                 print(self.a + self.b)
@@ -80,9 +80,9 @@ Options:
     def test_type_override(self):
         @classyclick.command()
         class Sum:
-            a: int = classyclick.argument()
+            a: int = classyclick.Argument()
             # bad type hint but the explicit one supersedes, so test still passes
-            b: str = classyclick.argument(type=int)
+            b: str = classyclick.Argument(type=int)
 
             def __call__(self):
                 print(self.a + self.b)
@@ -100,7 +100,7 @@ Options:
 
         @classyclick.command()
         class DP:
-            names: list[str] = classyclick.argument(nargs=2)
+            names: list[str] = classyclick.Argument(nargs=2)
 
             def __call__(self):
                 print(f'Hello, {" and ".join(self.names)}')

--- a/tests/test_command_context.py
+++ b/tests/test_command_context.py
@@ -25,18 +25,18 @@ class Test(BaseCase):
 
         @classyclick.command(group=cli)
         class Clone:
-            repo: Repo = classyclick.context_obj()
-            src: str = classyclick.argument()
-            dest: str = classyclick.argument(required=False)
+            repo: Repo = classyclick.ContextObj()
+            src: str = classyclick.Argument()
+            dest: str = classyclick.Argument(required=False)
 
             def __call__(self):
                 click.echo(f'Clone from {self.src} to {self.dest} at {self.repo.home}')
 
         @classyclick.command(group=cli)
         class Clone2:
-            ctx: Any = classyclick.context()
-            src: str = classyclick.argument()
-            dest: str = classyclick.argument(required=False)
+            ctx: Any = classyclick.Context()
+            src: str = classyclick.Argument()
+            dest: str = classyclick.Argument(required=False)
 
             def __call__(self):
                 click.echo(f'Clone from {self.src} to {self.dest} at {self.ctx.obj.home}')
@@ -67,10 +67,10 @@ class Test(BaseCase):
 
         @classyclick.command(group=cli)
         class Clone:
-            repo: str = classyclick.context_meta('repo')
-            debug: bool = classyclick.context_meta('debug')
-            src: str = classyclick.argument()
-            dest: str = classyclick.argument(required=False)
+            repo: str = classyclick.ContextMeta('repo')
+            debug: bool = classyclick.ContextMeta('debug')
+            src: str = classyclick.Argument()
+            dest: str = classyclick.Argument(required=False)
 
             def __call__(self):
                 click.echo(f'Clone from {self.src} to {self.dest} at {self.repo}')

--- a/tests/test_command_deprecated.py
+++ b/tests/test_command_deprecated.py
@@ -1,0 +1,32 @@
+import click
+from click.testing import CliRunner
+
+import classyclick
+from tests import BaseCase
+
+
+class Test(BaseCase):
+    def test_all(self):
+        @click.group()
+        @click.option('--country', default='Somewhere')
+        @click.pass_context
+        def cli(ctx, country):
+            ctx.obj = dict(country=country)
+            ctx.meta['country'] = country
+
+        @classyclick.command(group=cli)
+        class Hello:
+            name: str = classyclick.argument()
+            age: int = classyclick.option(required=True, help='Age')
+            country: str = classyclick.context_meta('country')
+            obj: any = classyclick.context_obj()
+            ctx: any = classyclick.context()
+
+            def __call__(self):
+                print(f'Hello, {self.name} from {self.country}, you will be {self.age + 1} next year')
+
+        runner = CliRunner()
+        result = runner.invoke(cli, ['hello', 'Peter', '--age', '10'])
+        self.assertEqual(result.exception, None)
+        self.assertEqual(result.exit_code, 0)
+        self.assertEqual(result.output, 'Hello, Peter from Somewhere, you will be 11 next year\n')

--- a/tests/test_command_deprecated.py
+++ b/tests/test_command_deprecated.py
@@ -7,6 +7,9 @@ from tests import BaseCase
 
 class Test(BaseCase):
     def test_all(self):
+        if self.click_version < (8, 0):
+            self.skipTest('pass_meta_key requires click 8.0')
+
         @click.group()
         @click.option('--country', default='Somewhere')
         @click.pass_context

--- a/tests/test_command_option.py
+++ b/tests/test_command_option.py
@@ -5,16 +5,10 @@ from tests import BaseCase
 
 
 class Test(BaseCase):
-    @property
-    def click_version(self):
-        from click import __version__
-
-        return tuple(map(int, __version__.split('.')))
-
     def test_option(self):
         @classyclick.command()
         class Hello:
-            name: str = classyclick.option(help='Name')
+            name: str = classyclick.Option(help='Name')
 
             def __call__(self):
                 print(f'Hello, {self.name}')
@@ -27,8 +21,8 @@ class Test(BaseCase):
     def test_type_inference_option(self):
         @classyclick.command()
         class Sum:
-            a: int = classyclick.option()
-            b: int = classyclick.option()
+            a: int = classyclick.Option()
+            b: int = classyclick.Option()
 
             def __call__(self):
                 print(self.a + self.b)
@@ -42,7 +36,7 @@ class Test(BaseCase):
         def _a():
             @classyclick.command()
             class Sum:
-                a: int = classyclick.option('arc')
+                a: int = classyclick.Option('arc')
 
                 def __call__(self):
                     print(self.a + self.b)
@@ -52,8 +46,8 @@ class Test(BaseCase):
     def test_no_default_parameter(self):
         @classyclick.command()
         class DP:
-            name: str = classyclick.option()
-            extra: str = classyclick.option('--xtra', default_parameter=False)
+            name: str = classyclick.Option()
+            extra: str = classyclick.Option('--xtra', default_parameter=False)
 
             def __call__(self):
                 print(f'Hello, {self.name}{self.extra}')
@@ -74,8 +68,8 @@ class Test(BaseCase):
 
         @classyclick.command()
         class DP:
-            greet: bool = classyclick.option()
-            other: bool = classyclick.option(is_flag=False)
+            greet: bool = classyclick.Option()
+            other: bool = classyclick.Option(is_flag=False)
 
             def __call__(self):
                 if self.greet:
@@ -102,7 +96,7 @@ class Test(BaseCase):
 
         @classyclick.command()
         class DP:
-            names: list[str] = classyclick.option('--name', default_parameter=False, metavar='NAME', multiple=True)
+            names: list[str] = classyclick.Option('--name', default_parameter=False, metavar='NAME', multiple=True)
 
             def __call__(self):
                 print(f'Hello, {" and ".join(self.names)}')
@@ -123,7 +117,7 @@ class Test(BaseCase):
 
         @classyclick.command()
         class DP:
-            names: list[str] = classyclick.option('--name', metavar='NAME', default_parameter=False, nargs=2)
+            names: list[str] = classyclick.Option('--name', metavar='NAME', default_parameter=False, nargs=2)
 
             def __call__(self):
                 print(f'Hello, {" and ".join(self.names)}')


### PR DESCRIPTION
Currently, class fields are assigned to `classyclick.option` (lowercased) but dataclasses and pydantic models are all assigned to `Field` (a class, capitalized).

Start doing the same!