### PR TITLE
Fix dataclass typehints

### DIFF
--- a/tests/test_command.py
+++ b/tests/test_command.py
@@ -123,16 +123,25 @@ class Test(BaseCase):
                 def __call__(self): ...
 
     def test_dataclass_typehints(self):
-        @classyclick.command()
+        @classyclick.command
         class Hello:
+            """test command docstring"""
+
             name: str = classyclick.Argument()
             age: int = classyclick.Option(default=10)
 
             def __call__(self):
+                """x"""
                 print(f'Hello {self.name}, gratz on being {self.age}')
+
+            def other_method(self):
+                """y"""
+                return 2
 
         with self.assertRaisesRegex(TypeError, "missing 1 required positional argument: 'name'"):
             Hello()
 
         self.assertEqual(Hello('x').age, 10)
+        self.assertEqual(Hello('x').other_method(), 2)
         self.assertEqual(str(inspect.signature(Hello)), '(name: str, age: int = 10) -> None')
+        self.assertEqual(inspect.cleandoc(Hello.__doc__), 'test command docstring')


### PR DESCRIPTION
vscode shows empty constructor for a command instead of displaying all the fields as it should (with updated defaults)

Example:

```python
        @classyclick.command()
        class BaseHello:
            name: str = classyclick.Argument()
            age: int = classyclick.Option(default=10)

            def __call__(self): ...
```

When typing `BaseHello(` nothing pops up as arguments

Expected something like `BaseHello(name: str, age: int = 10)`
