### PR TITLE
Improve library documentation site

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -4,6 +4,12 @@
 It keeps Click's behavior and parameter model, but moves command state onto an
 instance so helper methods and properties can use `self` directly.
 
+Python's `click` package is excellent, but its decorator-driven style can make
+commands harder to reuse outside the CLI entrypoint. Re-defining commands as
+dataclasses gives you regular Python objects that can still be invoked through
+Click, while also making non-Click use and command composition much more
+natural.
+
 The documentation is organized with the same split that works well in projects
 like Flask: start with the guide if you want to learn the library, then move to
 the API reference when you need exact behavior.
@@ -67,4 +73,5 @@ forwarded straight to Click, while the library adds a class-centric layer on top
 
 If you already know Click, you can treat `classyclick` as a thin adapter that
 lets you structure larger commands around methods and properties instead of
-passing the same values between functions.
+passing the same values between functions. That pays off most when you want to
+reuse command logic outside Click or compose one command from another.

--- a/docs/README.md
+++ b/docs/README.md
@@ -1,22 +1,31 @@
-# $ 🎩click✨_, _classyclick_
+# classyclick
 
-[![ci](https://github.com/fopina/classyclick/actions/workflows/publish-main.yml/badge.svg)](https://github.com/fopina/classyclick/actions/workflows/publish-main.yml)
-[![test](https://github.com/fopina/classyclick/actions/workflows/test.yml/badge.svg)](https://github.com/fopina/classyclick/actions/workflows/test.yml)
-[![codecov](https://codecov.io/github/fopina/classyclick/graph/badge.svg)](https://codecov.io/github/fopina/classyclick)
-[![PyPI pyversions](https://img.shields.io/pypi/pyversions/classyclick.svg)](https://pypi.org/project/classyclick/)
-[![Current version on PyPi](https://img.shields.io/pypi/v/classyclick)](https://pypi.org/project/classyclick/)
-[![Very popular](https://img.shields.io/pypi/dm/classyclick)](https://pypistats.org/packages/classyclick)
-[![Code style: black](https://img.shields.io/badge/code%20style-black-000000.svg)](https://github.com/psf/black)
+`classyclick` lets you define Click commands as classes instead of decorated functions.
+It keeps Click's behavior and parameter model, but moves command state onto an
+instance so helper methods and properties can use `self` directly.
 
-Class-based definitions of click commands
+The documentation is organized with the same split that works well in projects
+like Flask: start with the guide if you want to learn the library, then move to
+the API reference when you need exact behavior.
 
-```
+## What classyclick provides
+
+- `@classyclick.command()` to turn a class into a `click.Command`
+- `classyclick.Option` and `classyclick.Argument` field objects that map class
+  attributes to Click parameters
+- `classyclick.Context`, `classyclick.ContextObj`, and `classyclick.ContextMeta`
+  for injecting Click context values onto the command instance
+- `classyclick.Command` and `classyclick.Group` base classes for class-driven
+  command and group definitions without an extra decorator
+
+## Installation
+
+```bash
 pip install classyclick
 ```
 
-## A Simple Example
+## A minimal example
 
-<!-- example-id: tests/cli_hello_simple.py -->
 ```python
 import click
 
@@ -39,325 +48,23 @@ if __name__ == '__main__':
     Hello.click()
 ```
 
-<!-- example-id-output: tests/cli_hello_simple.py --name classyclick --count=3 -->
-```
-$ ./cli_hello_simple.py --name classyclick --count=3
-Hello, classyclick!
-Hello, classyclick!
-Hello, classyclick!
-```
+## Pick a path
 
-## Wait... huh?
+- The [Guide](guide.md) explains the main patterns and how the pieces fit
+  together.
+- The [API Reference](api.md) documents the exported classes, functions, and
+  helper utilities module by module.
 
-_This simple example has even more lines than [click's example](https://github.com/pallets/click/blob/main/README.md#a-simple-example)???_
+## Design notes
 
-Right, apart from personal aesthetics preferences, there is no reason to choose class-approach in this example.
+`classyclick` stays intentionally small. Most keyword arguments and behavior are
+forwarded straight to Click, while the library adds a class-centric layer on top:
 
-Reason why I started to use classes for commands is that, as the command function complexity grows, we decompose it into more functions:
+- field names become parameter names
+- type annotations become Click parameter types when possible
+- class docstrings become command help text unless you override them
+- the generated Click command is attached to the class as `.click`
 
-<!-- example-id: tests/cli_click_readme.py -->
-```python
-import click
-
-
-@click.command()
-@click.option('--count', default=1, help='Number of greetings.')
-@click.option('--name', prompt='Your name', help='The person to greet.')
-def hello(count, name):
-    """Simple program that greets reversed NAME for a total of COUNT times."""
-    greet(count, name)
-
-
-def greet(count, name):
-    for _ in range(count):
-        click.echo(f'Hello, {reverse(name)}!')
-
-
-def reverse(name):
-    return name[::-1]
-```
-
-See the parameters being passed around?  
-Easy to have multiple parameters required to several different functions.
-
-Refactoring to classyclick:
-
-<!-- example-id: tests/cli_hello.py --count=3 -->
-```python
-import click
-
-import classyclick
-
-
-@classyclick.command()
-class Hello:
-    """Simple program that greets NAME for a total of COUNT times."""
-
-    name: str = classyclick.Option(prompt='Your name', help='The person to greet.')
-    count: int = classyclick.Option(default=1, help='Number of greetings.')
-
-    def __call__(self):
-        self.greet()
-
-    def greet(self):
-        for _ in range(self.count):
-            click.echo(f'Hello, {self.reversed_name}!')
-
-    @property
-    def reversed_name(self):
-        return self.name[::-1]
-```
-
-## More docs please
-
-Not much to add to the simple example currently, as this mostly forwards everything to click, but here's something more then!
-
-### classyclick.command
-
-Use it just like [@click.command](https://click.palletsprojects.com/en/stable/api/#click.command) but decorating a **class** instead of a function (*classy*).
-
-The only new keyword argument is `group`. This can be used to attach the command a `click.group`.
-
-Re-using click examples:
-
-<!-- example-id: tests/cli_click.py --help -->
-```
-@click.group()
-@click.option('--debug/--no-debug', default=False)
-def cli(debug):
-    click.echo(f"Debug mode is {'on' if debug else 'off'}")
-
-@cli.command()  # @cli, not @click!
-def sync():
-    click.echo('Syncing')
-
-@classyclick.command(group=cli)  # classy! with group
-class AnotherSync:
-    ...
-```
-
-Same as `click.command`, you can choose a command `name` or allow it to derive it from class name (camel to kebab, instead of click's snake to kebab).
-
-It will also forward class `__doc__` to click to be used as description if not specified as keyword arg.
-
-### classyclick.Option
-
-Instead of the decorator approach, this is more like [Django's models](https://docs.djangoproject.com/en/dev/topics/db/models/) to take advantage of how parameters are enumerated.
-
-As you noticed from the example, there's no need to specify an option parameter name:
-
-<!-- example-id: tests/cli_short_samples.py:normal -->
-```
-count: int = classyclick.Option(default=1, help='Number of greetings.')
-```
-
-`classyclick` makes use of the field names to infer a default (`--count` in example).
-
-To add a short version *on top of it*:
-
-<!-- example-id: tests/cli_short_samples.py:short -->
-```
-count: int = classyclick.Option('-c', default=1, help='Number of greetings.')
-```
-
-And to only include the short, you can use the only keyword argument that is not forwarded to [@click.option](https://click.palletsprojects.com/en/stable/api/#click.option): `default_parameter`
-
-<!-- example-id: tests/cli_short_samples.py:defaultparam -->
-```
-count: int = classyclick.Option('-c', default_parameter=False, default=1, help='Number of greetings.')
-```
-
-`classyclick.Option` also infers **type** from type hints, then passed to `click.option`.
-
-<!-- example-id: tests/cli_short_samples.py:type -->
-```python
-    # The resulting click.option will use type=Path
-    output: Path = classyclick.Option()
-
-    # You can still override it and mix things if you want ¯\_(ツ)_/¯
-    other_output: any = classyclick.Option(type=str)
-```
-
-When type is `bool`, it will set `is_flag=True` as well. If for some reason you don't want that, it can still be overriden.
-
-<!-- example-id: tests/cli_short_samples.py:bool -->
-```python
-    # This results in click.option('--verbose', type=bool, is_flag=True)
-    verbose: bool = classyclick.Option()
-
-    # As mentioned, it can always be overriden if you need the weird behavior of a non-flag bool option...
-    weird: bool = classyclick.Option(is_flag=False)
-```
-
-### classyclick.Argument
-
-Similar to `classyclick.Option`, this is mostly wrapping [@click.argument](https://click.palletsprojects.com/en/stable/api/#click.argument) so it can be used in fields.
-
-Argument name is inferred from the field name and, same as `classyclick.Option`, type from field.type.  
-Again, type can be overriden, however not argument name as it has to match the property. For display purposes, you can use `metavar=`.
-
-<!-- example-id: tests/cli_next.py 3 -->
-```python
-@classyclick.command()
-class Next:
-    """Output the next number."""
-
-    your_number: int = classyclick.Argument()
-
-    def __call__(self):
-        click.echo(self.your_number + 1)
-```
-
-<!-- example-id-output: tests/cli_next.py --help -->
-```
-$ ./cli_next.py --help
-Usage: cli_next.py [OPTIONS] YOUR_NUMBER
-
-  Output the next number.
-
-Options:
-  --help  Show this message and exit.
-```
-
-<!-- example-id-output: tests/cli_next.py 5 -->
-```
-$ ./cli_four.py 5     
-6
-```
-
-### classyclick.Context
-
-Like [@click.pass_context](https://click.palletsprojects.com/en/stable/api/#click.pass_context), this exposes `click.Context` in a command property.
-
-<!-- example-id: tests/cli_next_ctx.py 3 -->
-```python
-@click.group()
-@click.pass_context
-def next_group(ctx):
-    ctx.obj = SimpleNamespace(step_number=4)
-
-
-@classyclick.command(group=next_group)
-class Next:
-    """Output the next number."""
-
-    your_number: int = classyclick.Argument()
-    the_context: Any = classyclick.Context()
-
-    def __call__(self):
-        click.echo(self.your_number + self.the_context.obj.step_number)
-```
-
-### classyclick.ContextObj
-
-Like [@click.pass_obj](https://click.palletsprojects.com/en/stable/api/#click.pass_obj), this assigns `click.Context.obj` to a command property, when you only want the user data rather than the whole context.
-
-<!-- example-id: tests/cli_next_ctx_obj.py 3 -->
-```python
-@classyclick.command(group=next_group)
-class Next:
-    """Output the next number."""
-
-    your_number: int = classyclick.Argument()
-    the_context: Any = classyclick.ContextObj()
-
-    def __call__(self):
-        click.echo(self.your_number + self.the_context.step_number)
-```
-
-### classyclick.ContextMeta
-
-Like [@click.pass_meta_key](https://click.palletsprojects.com/en/stable/api/#click.decorators.pass_meta_key), this assigns `click.Context.meta[KEY]` to a command property, without handling the whole context.
-
-<!-- example-id: tests/cli_next_ctx_meta.py 3 -->
-```python
-@click.group()
-@click.pass_context
-def next_group_meta(ctx):
-    ctx.meta['step_number'] = 5
-
-
-@classyclick.command(group=next_group_meta)
-class Next:
-    """Output the next number."""
-
-    your_number: int = classyclick.Argument()
-    step_number: int = classyclick.ContextMeta('step_number')
-
-    def __call__(self):
-        click.echo(self.your_number + self.step_number)
-```
-
-### Composition
-
-You can compose commands together as the wrapped class is just a `dataclass`.
-
-As example, if we wanted a `Bye` command just like the `Hello` example above, but with a small change, we can subclass `Hello`
-
-<!-- example-id: tests/cli_bye.py --count=1 -->
-```python
-import click
-from cli_hello import Hello
-
-import classyclick
-
-
-@classyclick.command()
-class Bye(Hello):
-    """Simple program that says bye to NAME for a total of COUNT times."""
-
-    def greet(self):
-        for _ in range(self.count):
-            click.echo(f'Bye, {self.reversed_name}!')
-```
-
-The command is subclassed, inheriting arguments/options (as they are dataclass fields) and any methods:
-
-<!-- example-id-output: tests/cli_bye.py --help -->
-```
-$ ./cli_bye.py --help
-Usage: cli_bye.py [OPTIONS]
-
-  Simple program that says bye to NAME for a total of COUNT times.
-
-Options:
-  --name TEXT      The person to greet.
-  --count INTEGER  Number of greetings.
-  --help           Show this message and exit.
-```
-
-### Testing
-
-`classyclick` is just a small wrapper around `click`, testing is the same as in [click's docs](https://click.palletsprojects.com/en/stable/testing/#basic-testing):
-
-Simply use `Command.click` with `CliRunner` for the same `click.testing` experience
-
-<!-- example-id: tests/test_hello_readme2.py --name Peter -->
-```python
-from click.testing import CliRunner
-
-# Hello being the example above that reverses name
-from .cli_hello import Hello
-
-
-def test_hello_world():
-    runner = CliRunner()
-    result = runner.invoke(Hello.click, ['--name', 'Peter'])
-    assert result.exit_code == 0
-    assert result.output == 'Hello, reteP!\n'
-```
-
-But you can also unit test specific methods of a command, skipping `CliRunner`.
-
-This might help reducing required test setup as you don't need to control complex code paths from entrypoint of the CLI command.
-
-<!-- example-id: tests/test_hello_readme.py --name Peter -->
-```python
-from .cli_hello import Hello
-
-
-def test_hello_world():
-    # for the example above that reverses the name
-    o = Hello('hello', 1)
-    assert o.reversed_name == 'olleh'
-```
+If you already know Click, you can treat `classyclick` as a thin adapter that
+lets you structure larger commands around methods and properties instead of
+passing the same values between functions.

--- a/docs/api.md
+++ b/docs/api.md
@@ -1,0 +1,303 @@
+# API Reference
+
+This reference follows the package layout in `classyclick/` and documents the
+library's public API first, then the internal helpers that appear in the source.
+
+## Package exports
+
+The top-level `classyclick` package re-exports the main public API from
+`classyclick.__init__`:
+
+- `__version__`, `version`
+- `command`
+- `Command`
+- `Group`
+- `Option`, `Argument`, `Context`, `ContextObj`, `ContextMeta`
+- `option`, `argument`, `context`, `context_obj`, `context_meta`
+
+Importing from the package root is the intended user-facing style.
+
+## `classyclick.__version__`
+
+### `version` and `__version__`
+
+String aliases for the installed package version.
+
+### `version_tuple` and `__version_tuple__`
+
+Tuple forms derived from `version.split('.')`. These exist in the module, but
+only the string versions are exported through `__all__`.
+
+## `classyclick.command`
+
+### `command(cls=None, *, group=None, **click_kwargs)`
+
+Decorator that turns a class into a Click command.
+
+Behavior:
+
+- validates that the decorated object is a class
+- converts the class to a dataclass with strict type checking for `classyclick`
+  fields
+- creates a wrapper callback that instantiates the class and calls its
+  `__call__()` method
+- applies every field object in reverse declaration order so Click sees
+  parameters in the expected order
+- registers the callback with either the provided `group` or plain `click`
+- stores the generated `click.Command` on the class as `.click`
+
+Use this when you want Click's decorator-style ergonomics but prefer to keep
+implementation state on a class instance.
+
+### `Clickable`
+
+`typing.Protocol` used for type hints. It describes an object with a `.click`
+attribute containing the generated `click.Command`.
+
+This is not a runtime feature; it exists to help type checkers understand what
+the decorator returns.
+
+### `Command`
+
+Base class for defining commands without using the `@command()` decorator.
+
+Key behavior:
+
+- subclasses must implement `__call__()`
+- subclasses are converted to dataclasses automatically
+- the Click command is built in `__init_subclass__`
+- the generated command is stored as `Class.click`
+
+This is the most direct choice when you want a class-first API.
+
+### `Command.click`
+
+Class attribute containing the generated `click.Command`.
+
+### `Command.__config__`
+
+Optional class attribute. Set this to a `Command.Config` instance to pass named
+configuration into Click command creation.
+
+### `Command.Config`
+
+Configuration container for `Command`.
+
+Constructor parameters:
+
+- `name`: override the generated command name
+- `help`: override the help text that would otherwise come from the class
+  docstring
+- `group`: register the command under a specific Click group
+- `**kwargs`: forwarded to `click.command()`
+
+### `Command.__init_subclass__(**kwargs)`
+
+Called automatically when a subclass is declared.
+
+It enforces that concrete command subclasses implement `__call__()` unless they
+opt out with `__classyclick_skip_build__`, then builds the Click command.
+
+### `Command._build_click_command()`
+
+Class method that delegates to the shared group/command builder in
+`classyclick.group`.
+
+This is effectively an internal extension point.
+
+## `classyclick.fields`
+
+### `Option(*param_decls, default_parameter=True, **attrs)`
+
+Field object that maps a class attribute to `click.option()`.
+
+Special behavior added by `classyclick`:
+
+- prepends the field name as the Click parameter name
+- adds a default long option such as `--dry-run` when
+  `default_parameter=True`
+- infers `type` from the field annotation when `type` is omitted
+- converts `bool` annotations into flags unless `is_flag` is already set
+- mirrors Click's required/default handling back onto the dataclass field
+
+Rules and caveats:
+
+- positional `param_decls` must start with `-`; the field name already supplies
+  the destination name
+- `required=True` makes the field a required dataclass field
+- declaration order still matters because the owning class becomes a dataclass
+
+### `Option.__call__(command)`
+
+Applies the stored option definition to a Click callback and returns the wrapped
+callback.
+
+### `Argument(*, type=None, **attrs)`
+
+Field object that maps a class attribute to `click.argument()`.
+
+Special behavior added by `classyclick`:
+
+- the argument name always comes from the field name
+- the annotation is used as `type` unless you provide one
+- required/optional status is mirrored back into the dataclass field default
+
+Because it represents a positional value, there is no equivalent to
+`default_parameter`.
+
+### `Argument.__call__(command)`
+
+Applies the argument definition to a Click callback.
+
+### `Context()`
+
+Field object that injects `click.Context`, similar to `click.pass_context`.
+
+Behavior:
+
+- stores the field name on a private `__classy_context__` list on the callback
+- wraps the callback with `click.pass_context`
+- defaults to `None` on the dataclass side so the field is optional
+
+### `ContextObj()`
+
+Like `Context()`, but injects `click.Context.obj` using `click.pass_obj`.
+
+### `ContextMeta(key, **attrs)`
+
+Injects `click.Context.meta[key]` using `click.decorators.pass_meta_key`.
+
+Unlike `Context` and `ContextObj`, this is required by default because Click
+raises `KeyError` when the key is missing.
+
+### Deprecated helper functions
+
+These helpers create the corresponding field objects and are marked deprecated in
+the source:
+
+- `option(*param_decls, default_parameter=True, **attrs)` -> `Option`
+- `argument(*, type=None, **attrs)` -> `Argument`
+- `context()` -> `Context`
+- `context_obj()` -> `ContextObj`
+- `context_meta(key, **attrs)` -> `ContextMeta`
+
+Prefer the capitalized class names in new code.
+
+### `_Field`
+
+Internal base class shared by all field types.
+
+It subclasses `dataclasses.Field`, stores Click attributes, infers types from
+annotations, and performs the trick that keeps Click's required/default behavior
+aligned with dataclass field defaults.
+
+This class is part of the implementation, not the supported public API.
+
+### `_FakeCommand`
+
+Internal helper used during field setup to let Click build a parameter object so
+`classyclick` can inspect the resulting default and required state.
+
+Application code should not use this directly.
+
+## `classyclick.group`
+
+### `Group`
+
+Base class for defining `click.Group` objects as classes.
+
+Like `Command`, it auto-builds the Click object during subclass creation, but it
+also wires helper base classes for nested commands.
+
+### `Group.click`
+
+Class attribute containing the generated `click.Group`.
+
+### `Group.__config__`
+
+Optional class attribute. Set this to `Group.Config(...)` to customize how the
+Click group is created.
+
+### `Group.Config`
+
+Configuration container for groups.
+
+Constructor parameters:
+
+- `name`: override the generated group name
+- `help`: override the group help text
+- `**kwargs`: forwarded to `click.group()`
+
+### `Group.__init_subclass__(**kwargs)`
+
+Builds the Click group for each concrete subclass and then binds helper base
+classes for nested commands and sub-groups.
+
+### `Group._build_click_group()`
+
+Class method that delegates to the shared command/group builder.
+
+### `Group._bind_children()`
+
+Creates and attaches four helper classes:
+
+- `Group.CommandMixin`
+- `Group.SubGroupMixin`
+- `Group.Command`
+- `Group.SubGroup`
+
+These helper bases carry the parent group configuration so child command classes
+register themselves beneath the group automatically.
+
+### `Group.__call__()`
+
+Placeholder implementation so groups do not need to define a body unless they
+want startup behavior of their own.
+
+### `_build_click_class_command(cls, *, is_group=False)`
+
+Internal shared builder used by both `Command` and `Group`.
+
+It:
+
+- converts the class into a dataclass
+- creates the wrapper callback
+- applies all field objects
+- merges configuration from `__config__` and `__click_*__` class attributes
+- resolves parent-group registration rules
+- registers either a `click.Command` or `click.Group`
+
+### `_get_base_group_config(cls)`
+
+Internal helper that walks the class MRO looking for inherited group-binding
+configuration.
+
+## `classyclick.utils`
+
+### `camel_kebab(camel_value)`
+
+Converts `CamelCase` into `camel-case`.
+
+### `camel_snake(camel_value)`
+
+Converts `CamelCase` into `camel_case`.
+
+This is used when generating the intermediate callback name before Click applies
+its own command-name normalization.
+
+### `snake_kebab(snake_value)`
+
+Converts `snake_case` into `snake-case`.
+
+This is used for auto-generated option names such as `--dry-run`.
+
+### `strictly_typed_dataclass(kls)`
+
+Wraps `dataclasses.dataclass()` but first checks that every `classyclick` field
+has a type annotation.
+
+If a field object such as `Option()` or `Argument()` appears without a matching
+annotation, it raises `TypeError`.
+
+This function is a core internal guardrail and can also be useful when reading
+stack traces from invalid command declarations.

--- a/docs/guide.md
+++ b/docs/guide.md
@@ -1,0 +1,235 @@
+# Guide
+
+This guide focuses on how `classyclick` is meant to be used in application code.
+For exact signatures and lower-level details, see the [API Reference](api.md).
+
+## Two ways to define commands
+
+`classyclick` supports two styles:
+
+- Decorate a plain class with `@classyclick.command()`
+- Subclass `classyclick.Command`
+
+The decorator style is explicit and mirrors Click:
+
+```python
+import click
+
+import classyclick
+
+
+@classyclick.command()
+class Hello:
+    name: str = classyclick.Option(prompt='Your name')
+
+    def __call__(self):
+        click.echo(f'Hello, {self.name}!')
+```
+
+The base-class style wires the Click command automatically when the subclass is
+created:
+
+```python
+import click
+
+from classyclick import Command, Option
+
+
+class Hello(Command):
+    name: str = Option(prompt='Your name')
+
+    def __call__(self):
+        click.echo(f'Hello, {self.name}!')
+```
+
+In either case, the generated Click command is available as `Hello.click`.
+
+## How fields become Click parameters
+
+`classyclick.Option` and `classyclick.Argument` are dataclass-like field objects.
+When the command class is processed:
+
+1. the class is converted to a dataclass
+2. each field is read in declaration order
+3. each `Option`, `Argument`, or context field wraps the generated Click
+   callback
+
+That gives you one place to define the CLI surface and one place to implement
+behavior.
+
+### Options
+
+Use `Option` for named parameters:
+
+```python
+from pathlib import Path
+
+from classyclick import Command, Option
+
+
+class Build(Command):
+    output: Path = Option(help='Where to write the build output.')
+    verbose: bool = Option(help='Enable verbose logging.')
+```
+
+Important behaviors:
+
+- the field name is used as the Python parameter name
+- `default_parameter=True` adds a long option such as `--output`
+- extra positional declarations such as `'-o'` are forwarded to Click
+- type annotations are used as the Click `type` when you do not provide one
+- `bool` fields become flags by default unless you override `is_flag`
+
+Examples:
+
+```python
+count: int = Option(default=1)
+count: int = Option('-c', default=1)
+count: int = Option('-c', default_parameter=False, default=1)
+```
+
+### Arguments
+
+Use `Argument` for positional values:
+
+```python
+from classyclick import Argument, Command
+
+
+class Next(Command):
+    your_number: int = Argument()
+
+    def __call__(self):
+        print(self.your_number + 1)
+```
+
+Important behaviors:
+
+- the argument name always comes from the field name
+- the annotation is used as the Click `type` unless you override it
+- `Argument` is required by default, matching Click's usual behavior
+- if Click determines the argument is optional, the dataclass default is set to
+  `None`
+
+### Context injection
+
+Use context fields when the command implementation needs `click.Context` data:
+
+```python
+import click
+
+from classyclick import Command, Context, ContextMeta, ContextObj
+
+
+class ShowState(Command):
+    request_id: str = ContextMeta('request_id')
+    ctx: click.Context = Context()
+    obj: object = ContextObj()
+
+    def __call__(self):
+        print(self.ctx.command_path, self.obj, self.request_id)
+```
+
+The three context helpers map directly to Click decorators:
+
+- `Context()` behaves like `click.pass_context`
+- `ContextObj()` behaves like `click.pass_obj`
+- `ContextMeta('key')` behaves like `click.decorators.pass_meta_key`
+
+These values are pushed into the generated callback and then copied into the
+class instance before `__call__()` runs.
+
+## Names, help text, and Click kwargs
+
+By default, `classyclick` derives the Click callback name from the class name:
+
+- class name `HelloWorld` becomes callback name `hello_world`
+- Click then applies its normal command-name conversion, typically resulting in
+  `hello-world`
+
+The class docstring becomes the command help text unless you provide `help=`
+explicitly.
+
+You can pass normal Click configuration in two ways:
+
+### On the decorator
+
+```python
+@classyclick.command(name='hello-there', help='Friendly greeting command.')
+class Hello:
+    ...
+```
+
+### On `Command.Config`
+
+```python
+from classyclick import Command
+
+
+class Hello(Command):
+    __config__ = Command.Config(name='hello-there', help='Friendly greeting command.')
+```
+
+`Command.Config` also accepts `group=` so a command can register itself under a
+specific Click group.
+
+## Working with groups
+
+For grouped CLIs, subclass `classyclick.Group`:
+
+```python
+import click
+
+from classyclick import Group, Option
+
+
+class CLI(Group):
+    debug: bool = Option(default=False)
+
+    def __call__(self):
+        click.echo(f'debug={self.debug}')
+
+
+class Hello(CLI.Command):
+    name: str = Option(prompt='Your name')
+
+    def __call__(self):
+        click.echo(f'Hello, {self.name}!')
+```
+
+When a `Group` subclass is created, `classyclick`:
+
+- builds a `click.Group` and stores it as `.click`
+- creates `Group.Command` and `Group.SubGroup` helper base classes
+- binds those helper bases so child commands and sub-groups register beneath the
+  parent group automatically
+
+This gives you a compact way to build nested CLIs while keeping each command as
+its own class.
+
+## Required field ordering
+
+Because command classes are converted to dataclasses, dataclass ordering rules
+still apply:
+
+- required fields must come before optional fields
+- this matters for `Argument`, `Option(required=True)`, and `ContextMeta`
+- optional context values such as `Context` and `ContextObj` should be declared
+  after required fields
+
+If a class contains a `classyclick` field without a type annotation,
+`strictly_typed_dataclass()` raises a `TypeError`.
+
+## Deprecated lowercase helpers
+
+The lowercase helpers are still available:
+
+- `classyclick.option()`
+- `classyclick.argument()`
+- `classyclick.context()`
+- `classyclick.context_obj()`
+- `classyclick.context_meta()`
+
+They return the same field objects as the capitalized classes, but they are
+marked deprecated in the source. Prefer `Option`, `Argument`, `Context`,
+`ContextObj`, and `ContextMeta` in new code.

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -1,12 +1,12 @@
 site_name: classyclick
 
 nav:
-  - Contents:
-    - Library: README.md
+  - Home: README.md
+  - Guide: guide.md
+  - API Reference: api.md
   - Project Links:
     - Github: https://github.com/fopina/classyclick/
-    - PyPI: https://test.pypi.org/project/classyclick/
+    - PyPI: https://pypi.org/project/classyclick/
 
 theme:
   name: readthedocs
-


### PR DESCRIPTION
## Summary
- replace the single-page docs landing page with a clearer home page
- add a guide covering command, field, context, and group usage patterns
- add an API reference and update MkDocs navigation links

## Testing
- not run (docs-only changes)

---

relates to #56 