### PR TITLE
Add support for extra Click decorators in Config

### DIFF
--- a/classyclick/command.py
+++ b/classyclick/command.py
@@ -76,8 +76,16 @@ class Command:
     """
 
     class Config:
-        def __init__(self, *, name: str = None, help: str = None, group: 'click.Group' = None, **kwargs):
-            self.__dict__.update(name=name, help=help, group=group, **kwargs)
+        def __init__(
+            self,
+            *,
+            name: str = None,
+            help: str = None,
+            group: 'click.Group' = None,
+            decorators=None,
+            **kwargs,
+        ):
+            self.__dict__.update(name=name, help=help, group=group, decorators=decorators, **kwargs)
 
     def __init_subclass__(cls, **kwargs):
         super().__init_subclass__(**kwargs)

--- a/classyclick/group.py
+++ b/classyclick/group.py
@@ -14,6 +14,14 @@ def _get_base_group_config(cls):
     return None
 
 
+def _normalize_click_decorators(decorators):
+    if decorators is None:
+        return ()
+    if callable(decorators):
+        return (decorators,)
+    return tuple(decorators)
+
+
 def _build_click_class_command(cls, *, is_group=False):
     doc = utils.get_inherited_doc(cls)
     utils.strictly_typed_dataclass(cls)
@@ -43,6 +51,8 @@ def _build_click_class_command(cls, *, is_group=False):
             if key and key not in click_kwargs:
                 click_kwargs[key] = value
 
+    click_decorators = _normalize_click_decorators(click_kwargs.pop('decorators', None))
+
     click_group = click_kwargs.pop('group', None)
     if click_group is None:
         click_group = _get_base_group_config(cls)
@@ -55,6 +65,8 @@ def _build_click_class_command(cls, *, is_group=False):
         cls.__command__ = click_group.group(**click_kwargs)(func)
     else:
         cls.__command__ = click_group.command(**click_kwargs)(func)
+    for decorator in click_decorators:
+        cls.__command__ = decorator(cls.__command__)
     cls.click = cls.__command__
 
 
@@ -72,8 +84,8 @@ class Group:
     """
 
     class Config:
-        def __init__(self, *, name: str = None, help: str = None, **kwargs):
-            self.__dict__.update(name=name, help=help, **kwargs)
+        def __init__(self, *, name: str = None, help: str = None, decorators=None, **kwargs):
+            self.__dict__.update(name=name, help=help, decorators=decorators, **kwargs)
 
     def __init_subclass__(cls, **kwargs):
         super().__init_subclass__(**kwargs)

--- a/tests/test_command_v2.py
+++ b/tests/test_command_v2.py
@@ -1,3 +1,4 @@
+import click
 from click.testing import CliRunner
 
 import classyclick
@@ -232,6 +233,22 @@ Options:
   --help         Show this message and exit.
 """,
         )
+
+    def test_config_supports_extra_click_decorators(self):
+        class Hello(classyclick.Command):
+            __config__ = classyclick.Command.Config(
+                decorators=click.version_option(version='1.2.3', message='%(version)s'),
+            )
+
+            def __call__(self): ...
+
+        help_result = self.runner.invoke(Hello.click, args=['--help'])
+        self.assertEqual(help_result.exit_code, 0)
+        self.assertIn('--version  Show the version and exit.', help_result.output)
+
+        version_result = self.runner.invoke(Hello.click, args=['--version'])
+        self.assertEqual(version_result.exit_code, 0)
+        self.assertEqual(version_result.output, '1.2.3\n')
 
     def test_subclassing(self):
         class Hello(classyclick.Command):

--- a/tests/test_group.py
+++ b/tests/test_group.py
@@ -94,6 +94,20 @@ Options:
 """,
         )
 
+    def test_group_config_supports_extra_click_decorators(self):
+        class Cli(classyclick.Group):
+            __config__ = classyclick.Group.Config(
+                decorators=click.version_option(version='2.3.4', message='%(version)s'),
+            )
+
+        help_result = self.runner.invoke(Cli.click, args=['--help'])
+        self.assertEqual(help_result.exit_code, 0)
+        self.assertIn('--version  Show the version and exit.', help_result.output)
+
+        version_result = self.runner.invoke(Cli.click, args=['--version'])
+        self.assertEqual(version_result.exit_code, 0)
+        self.assertEqual(version_result.output, '2.3.4\n')
+
     def test_group_fields_and_subcommands(self):
         class Cli(classyclick.Group):
             """test group"""


### PR DESCRIPTION
## Summary
- add a decorators config option for classyclick.Command.Config and classyclick.Group.Config
- apply extra Click decorators after the command or group object is built so helpers like click.version_option(...) work on class-based CLIs
- add regression coverage for command and group version decorators

## Testing
- make lint
- make test

Closes #48