### PR TITLE
docs: align docs with class-based API

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,6 +14,10 @@ Class-based definitions of click commands
 pip install classyclick
 ```
 
+> Deprecated decorators and lowercase helpers were removed in `v1.0.0`. If
+> you're using an older release, see the
+> [`0.11.0` documentation](https://classyclick.readthedocs.io/en/0.11.0/).
+
 ## A Simple Example
 
 <!-- example-id: tests/cli_hello_simple.py -->

--- a/docs/README.md
+++ b/docs/README.md
@@ -14,6 +14,10 @@ The documentation is organized with the same split that works well in projects
 like Flask: start with the guide if you want to learn the library, then move to
 the API reference when you need exact behavior.
 
+> Deprecated decorators and lowercase helpers were removed in `v1.0.0`. If
+> you're using an older release, see the
+> [`0.11.0` documentation](https://classyclick.readthedocs.io/en/0.11.0/).
+
 ## What classyclick provides
 
 - `classyclick.Command` and `classyclick.Group` base classes for class-driven

--- a/docs/README.md
+++ b/docs/README.md
@@ -16,13 +16,13 @@ the API reference when you need exact behavior.
 
 ## What classyclick provides
 
-- `@classyclick.command()` to turn a class into a `click.Command`
+- `classyclick.Command` and `classyclick.Group` base classes for class-driven
+  command and group definitions
 - `classyclick.Option` and `classyclick.Argument` field objects that map class
   attributes to Click parameters
 - `classyclick.Context`, `classyclick.ContextObj`, and `classyclick.ContextMeta`
   for injecting Click context values onto the command instance
-- `classyclick.Command` and `classyclick.Group` base classes for class-driven
-  command and group definitions without an extra decorator
+- `.click` objects generated automatically from those classes
 
 ## Installation
 
@@ -38,8 +38,7 @@ import click
 import classyclick
 
 
-@classyclick.command()
-class Hello:
+class Hello(classyclick.Command):
     """Simple program that greets NAME for a total of COUNT times."""
 
     name: str = classyclick.Option(prompt='Your name', help='The person to greet.')

--- a/docs/api.md
+++ b/docs/api.md
@@ -12,8 +12,6 @@ The top-level `classyclick` package re-exports the main public API from
 - `Command`
 - `Group`
 - `Option`, `Argument`, `Context`, `ContextObj`, `ContextMeta`
-- `command`
-- `option`, `argument`, `context`, `context_obj`, `context_meta`
 
 Importing from the package root is the intended user-facing style.
 
@@ -27,8 +25,6 @@ String aliases for the installed package version.
 
 Tuple forms derived from `version.split('.')`. These exist in the module, but
 only the string versions are exported through `__all__`.
-
-## `classyclick.command`
 
 ### `Command`
 
@@ -77,25 +73,6 @@ Class method that delegates to the shared group/command builder in
 `classyclick.group`.
 
 This is effectively an internal extension point.
-
-### `command(cls=None, *, group=None, **click_kwargs)`
-
-Compatibility decorator that turns a class into a Click command.
-
-It follows the same build path as `Command`, including dataclass conversion,
-field processing, callback creation, and storing the generated Click command on
-the class as `.click`.
-
-Prefer subclassing `Command` in new code. This decorator remains useful when
-you need to adapt an existing plain class without changing its base class.
-
-### `Clickable`
-
-`typing.Protocol` used for type hints. It describes an object with a `.click`
-attribute containing the generated `click.Command`.
-
-This is not a runtime feature; it exists to help type checkers understand what
-the decorator returns.
 
 ## `classyclick.fields`
 
@@ -161,19 +138,6 @@ Injects `click.Context.meta[key]` using `click.decorators.pass_meta_key`.
 
 Unlike `Context` and `ContextObj`, this is required by default because Click
 raises `KeyError` when the key is missing.
-
-### Lowercase helper functions
-
-These helpers create the corresponding field objects and are kept for
-compatibility:
-
-- `option(*param_decls, default_parameter=True, **attrs)` -> `Option`
-- `argument(*, type=None, **attrs)` -> `Argument`
-- `context()` -> `Context`
-- `context_obj()` -> `ContextObj`
-- `context_meta(key, **attrs)` -> `ContextMeta`
-
-Prefer the capitalized class names in new code.
 
 ### `_Field`
 

--- a/docs/api.md
+++ b/docs/api.md
@@ -9,10 +9,10 @@ The top-level `classyclick` package re-exports the main public API from
 `classyclick.__init__`:
 
 - `__version__`, `version`
-- `command`
 - `Command`
 - `Group`
 - `Option`, `Argument`, `Context`, `ContextObj`, `ContextMeta`
+- `command`
 - `option`, `argument`, `context`, `context_obj`, `context_meta`
 
 Importing from the package root is the intended user-facing style.
@@ -30,36 +30,9 @@ only the string versions are exported through `__all__`.
 
 ## `classyclick.command`
 
-### `command(cls=None, *, group=None, **click_kwargs)`
-
-Decorator that turns a class into a Click command.
-
-Behavior:
-
-- validates that the decorated object is a class
-- converts the class to a dataclass with strict type checking for `classyclick`
-  fields
-- creates a wrapper callback that instantiates the class and calls its
-  `__call__()` method
-- applies every field object in reverse declaration order so Click sees
-  parameters in the expected order
-- registers the callback with either the provided `group` or plain `click`
-- stores the generated `click.Command` on the class as `.click`
-
-Use this when you want Click's decorator-style ergonomics but prefer to keep
-implementation state on a class instance.
-
-### `Clickable`
-
-`typing.Protocol` used for type hints. It describes an object with a `.click`
-attribute containing the generated `click.Command`.
-
-This is not a runtime feature; it exists to help type checkers understand what
-the decorator returns.
-
 ### `Command`
 
-Base class for defining commands without using the `@command()` decorator.
+Base class for defining commands.
 
 Key behavior:
 
@@ -104,6 +77,25 @@ Class method that delegates to the shared group/command builder in
 `classyclick.group`.
 
 This is effectively an internal extension point.
+
+### `command(cls=None, *, group=None, **click_kwargs)`
+
+Compatibility decorator that turns a class into a Click command.
+
+It follows the same build path as `Command`, including dataclass conversion,
+field processing, callback creation, and storing the generated Click command on
+the class as `.click`.
+
+Prefer subclassing `Command` in new code. This decorator remains useful when
+you need to adapt an existing plain class without changing its base class.
+
+### `Clickable`
+
+`typing.Protocol` used for type hints. It describes an object with a `.click`
+attribute containing the generated `click.Command`.
+
+This is not a runtime feature; it exists to help type checkers understand what
+the decorator returns.
 
 ## `classyclick.fields`
 
@@ -170,10 +162,10 @@ Injects `click.Context.meta[key]` using `click.decorators.pass_meta_key`.
 Unlike `Context` and `ContextObj`, this is required by default because Click
 raises `KeyError` when the key is missing.
 
-### Deprecated helper functions
+### Lowercase helper functions
 
-These helpers create the corresponding field objects and are marked deprecated in
-the source:
+These helpers create the corresponding field objects and are kept for
+compatibility:
 
 - `option(*param_decls, default_parameter=True, **attrs)` -> `Option`
 - `argument(*, type=None, **attrs)` -> `Argument`

--- a/docs/guide.md
+++ b/docs/guide.md
@@ -3,31 +3,10 @@
 This guide focuses on how `classyclick` is meant to be used in application code.
 For exact signatures and lower-level details, see the [API Reference](api.md).
 
-## Two ways to define commands
+## Define commands with classes
 
-`classyclick` supports two styles:
-
-- Decorate a plain class with `@classyclick.command()`
-- Subclass `classyclick.Command`
-
-The decorator style is explicit and mirrors Click:
-
-```python
-import click
-
-import classyclick
-
-
-@classyclick.command()
-class Hello:
-    name: str = classyclick.Option(prompt='Your name')
-
-    def __call__(self):
-        click.echo(f'Hello, {self.name}!')
-```
-
-The base-class style wires the Click command automatically when the subclass is
-created:
+Subclass `classyclick.Command` and implement `__call__()`. The Click command is
+built automatically when the class is created:
 
 ```python
 import click
@@ -42,7 +21,7 @@ class Hello(Command):
         click.echo(f'Hello, {self.name}!')
 ```
 
-In either case, the generated Click command is available as `Hello.click`.
+The generated Click command is available as `Hello.click`.
 
 ## How fields become Click parameters
 
@@ -150,17 +129,7 @@ By default, `classyclick` derives the Click callback name from the class name:
 The class docstring becomes the command help text unless you provide `help=`
 explicitly.
 
-You can pass normal Click configuration in two ways:
-
-### On the decorator
-
-```python
-@classyclick.command(name='hello-there', help='Friendly greeting command.')
-class Hello:
-    ...
-```
-
-### On `Command.Config`
+You can pass normal Click configuration on `Command.Config`:
 
 ```python
 from classyclick import Command
@@ -220,7 +189,7 @@ still apply:
 If a class contains a `classyclick` field without a type annotation,
 `strictly_typed_dataclass()` raises a `TypeError`.
 
-## Deprecated lowercase helpers
+## Lowercase helpers
 
 The lowercase helpers are still available:
 
@@ -230,6 +199,6 @@ The lowercase helpers are still available:
 - `classyclick.context_obj()`
 - `classyclick.context_meta()`
 
-They return the same field objects as the capitalized classes, but they are
-marked deprecated in the source. Prefer `Option`, `Argument`, `Context`,
-`ContextObj`, and `ContextMeta` in new code.
+They return the same field objects as the capitalized classes, but are kept for
+compatibility. Prefer `Option`, `Argument`, `Context`, `ContextObj`, and
+`ContextMeta` in new code.

--- a/docs/guide.md
+++ b/docs/guide.md
@@ -188,17 +188,3 @@ still apply:
 
 If a class contains a `classyclick` field without a type annotation,
 `strictly_typed_dataclass()` raises a `TypeError`.
-
-## Lowercase helpers
-
-The lowercase helpers are still available:
-
-- `classyclick.option()`
-- `classyclick.argument()`
-- `classyclick.context()`
-- `classyclick.context_obj()`
-- `classyclick.context_meta()`
-
-They return the same field objects as the capitalized classes, but are kept for
-compatibility. Prefer `Option`, `Argument`, `Context`, `ContextObj`, and
-`ContextMeta` in new code.


### PR DESCRIPTION
## Summary
- update docs/ to focus on the class-based API, matching the README follow-up from PR #64
- remove decorator-first guidance from the docs landing page and guide
- reframe classyclick.command and lowercase helpers in the API reference as compatibility paths

## Context
- follow-up from PR #64
- relates to #47
- relates to #62