### PR TITLE
Fix command composition issues with .Arguments

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,5 +1,17 @@
 all: lint test
 
+sync:
+	uv sync --dev --all-extras
+
+.venv39: export VIRTUAL_ENV=.venv39
+.venv39:
+	uv sync --dev --all-extras --python 3.9 --active
+
+test39: .venv39
+test39: export VIRTUAL_ENV=.venv39
+test39:
+	uv run --active pytest --cov
+
 lint:
 	uv run ruff format
 	uv run ruff check --fix

--- a/Makefile
+++ b/Makefile
@@ -12,6 +12,15 @@ test39: export VIRTUAL_ENV=.venv39
 test39:
 	uv run --active pytest --cov
 
+.venv310: export VIRTUAL_ENV=.venv310
+.venv310:
+	uv sync --dev --all-extras --python 3.10 --active
+
+test310: .venv310
+test310: export VIRTUAL_ENV=.venv310
+test310:
+	uv run --active pytest --cov
+
 lint:
 	uv run ruff format
 	uv run ruff check --fix

--- a/classyclick/utils.py
+++ b/classyclick/utils.py
@@ -1,8 +1,8 @@
 import inspect
 import re
-from dataclasses import dataclass
+from dataclasses import MISSING, dataclass, fields
 
-from classyclick.fields import _Field
+from classyclick.fields import Argument, ContextMeta, Option, _Field
 
 try:
     from typing import dataclass_transform
@@ -57,7 +57,130 @@ def strictly_typed_dataclass(kls):
             continue
         if name not in annotations and isinstance(val, _Field):
             raise TypeError(f"{kls.__module__}.{kls.__qualname__} is missing type for classy field '{name}'")
-    return dataclass(kls)
+    kls = dataclass(kls, init=False)
+    _validate_local_field_order(kls)
+    _build_init(kls)
+    return kls
+
+
+def _validate_local_field_order(kls):
+    local_annotations = getattr(kls, '__annotations__', {})
+    dataclass_fields = kls.__dataclass_fields__
+    previous_default = None
+    for name in local_annotations:
+        if name.startswith('__'):
+            continue
+
+        value = dataclass_fields[name]
+        has_default = not _field_is_required_for_init(value)
+
+        if has_default:
+            previous_default = name
+        elif previous_default is not None:
+            raise TypeError(f"non-default argument '{name}' follows default argument '{previous_default}'")
+
+
+def _build_init(kls):
+    if '__init__' in kls.__dict__:
+        return
+
+    init_fields = tuple(field for field in fields(kls) if field.init)
+    positional_fields = []
+    for field in init_fields:
+        if getattr(field, 'kw_only', False):
+            continue
+        positional_fields.append(field)
+        if not _field_is_required_for_init(field):
+            break
+    positional_fields = tuple(positional_fields)
+
+    def __init__(self, *args, **kwargs):
+        if len(args) > len(positional_fields):
+            raise TypeError(
+                f'{kls.__name__}.__init__() takes {len(positional_fields) + 1} positional arguments '
+                f'but {len(args) + 1} were given'
+            )
+
+        remaining_kwargs = dict(kwargs)
+        missing = []
+
+        for index, field in enumerate(positional_fields):
+            if index < len(args):
+                value = args[index]
+                if field.name in remaining_kwargs:
+                    raise TypeError(f"{kls.__name__}.__init__() got multiple values for argument '{field.name}'")
+            elif field.name in remaining_kwargs:
+                value = remaining_kwargs.pop(field.name)
+            elif field.default is not MISSING:
+                value = field.default
+            elif field.default_factory is not MISSING:
+                value = field.default_factory()
+            else:
+                missing.append(field.name)
+                continue
+
+            setattr(self, field.name, value)
+
+        for field in init_fields[len(positional_fields) :]:
+            if field.name in remaining_kwargs:
+                value = remaining_kwargs.pop(field.name)
+            elif field.default is not MISSING:
+                value = field.default
+            elif field.default_factory is not MISSING:
+                value = field.default_factory()
+            else:
+                missing.append(field.name)
+                continue
+
+            setattr(self, field.name, value)
+
+        if missing:
+            raise TypeError(_format_missing_message(kls, missing))
+
+        if remaining_kwargs:
+            unexpected = next(iter(remaining_kwargs))
+            raise TypeError(f"{kls.__name__}.__init__() got an unexpected keyword argument '{unexpected}'")
+
+        post_init = getattr(self, '__post_init__', None)
+        if post_init is not None:
+            post_init()
+
+    kls.__init__ = __init__
+
+
+def _format_missing_message(kls, missing):
+    count = len(missing)
+    if count == 1:
+        names = f"'{missing[0]}'"
+    elif count == 2:
+        names = f"'{missing[0]}' and '{missing[1]}'"
+    else:
+        names = ', '.join(f"'{name}'" for name in missing[:-1]) + f", and '{missing[-1]}'"
+    return f'{kls.__name__}.__init__() missing {count} required positional argument{"s" if count != 1 else ""}: {names}'
+
+
+def _field_has_python_default(field):
+    if field.default_factory is not MISSING:
+        return True
+    if field.default is MISSING:
+        return False
+    return not _is_click_unset(field.default)
+
+
+def _field_is_required_for_init(field):
+    if _field_has_python_default(field):
+        return False
+    if isinstance(field, Option):
+        return field.attrs.get('required', False) or bool(field.attrs.get('prompt'))
+    if isinstance(field, Argument):
+        return field.attrs.get('required', True)
+    if isinstance(field, ContextMeta):
+        return True
+    return field.default is MISSING and field.default_factory is MISSING
+
+
+def _is_click_unset(value):
+    return type(value).__module__ == 'click._utils' and type(value).__qualname__ == 'Sentinel' and value.name == 'UNSET'
 
 
 __all__ = ['dataclass_transform']

--- a/classyclick/utils.py
+++ b/classyclick/utils.py
@@ -51,7 +51,7 @@ def get_inherited_doc(kls):
 
 
 def strictly_typed_dataclass(kls):
-    annotations = getattr(kls, '__annotations__', {})
+    annotations = kls.__dict__.get('__annotations__', {})
     for name, val in kls.__dict__.items():
         if name.startswith('__'):
             continue
@@ -64,7 +64,7 @@ def strictly_typed_dataclass(kls):
 
 
 def _validate_local_field_order(kls):
-    local_annotations = getattr(kls, '__annotations__', {})
+    local_annotations = kls.__dict__.get('__annotations__', {})
     dataclass_fields = kls.__dataclass_fields__
     previous_default = None
     for name in local_annotations:
@@ -105,12 +105,16 @@ def _build_init(kls):
         missing = []
 
         for index, field in enumerate(positional_fields):
+            required_for_init = _field_is_required_for_init(field)
             if index < len(args):
                 value = args[index]
                 if field.name in remaining_kwargs:
                     raise TypeError(f"{kls.__name__}.__init__() got multiple values for argument '{field.name}'")
             elif field.name in remaining_kwargs:
                 value = remaining_kwargs.pop(field.name)
+            elif required_for_init:
+                missing.append(field.name)
+                continue
             elif field.default is not MISSING:
                 value = field.default
             elif field.default_factory is not MISSING:
@@ -122,8 +126,12 @@ def _build_init(kls):
             setattr(self, field.name, value)
 
         for field in init_fields[len(positional_fields) :]:
+            required_for_init = _field_is_required_for_init(field)
             if field.name in remaining_kwargs:
                 value = remaining_kwargs.pop(field.name)
+            elif required_for_init:
+                missing.append(field.name)
+                continue
             elif field.default is not MISSING:
                 value = field.default
             elif field.default_factory is not MISSING:
@@ -168,14 +176,20 @@ def _field_has_python_default(field):
 
 
 def _field_is_required_for_init(field):
-    if _field_has_python_default(field):
-        return False
     if isinstance(field, Option):
-        return field.attrs.get('required', False) or bool(field.attrs.get('prompt'))
+        if field.attrs.get('required', False):
+            return 'default' not in field.attrs and field.default_factory is MISSING
+        if field.attrs.get('prompt') and 'default' not in field.attrs and field.default_factory is MISSING:
+            return True
+        return not _field_has_python_default(field)
     if isinstance(field, Argument):
+        if _field_has_python_default(field):
+            return False
         return field.attrs.get('required', True)
     if isinstance(field, ContextMeta):
         return True
+    if _field_has_python_default(field):
+        return False
     return field.default is MISSING and field.default_factory is MISSING
 
 

--- a/classyclick/utils.py
+++ b/classyclick/utils.py
@@ -51,6 +51,9 @@ def get_inherited_doc(kls):
 
 
 def strictly_typed_dataclass(kls):
+    # Python 3.9 can expose inherited annotations via getattr(..., '__annotations__'),
+    # which makes base helper attributes like `click` look like local dataclass fields.
+    # Once Python 3.9 support is dropped, revisit whether this can be simplified.
     annotations = kls.__dict__.get('__annotations__', {})
     for name, val in kls.__dict__.items():
         if name.startswith('__'):
@@ -64,6 +67,8 @@ def strictly_typed_dataclass(kls):
 
 
 def _validate_local_field_order(kls):
+    # Same Python 3.9 compatibility note as in strictly_typed_dataclass():
+    # only consider annotations declared on this class body.
     local_annotations = kls.__dict__.get('__annotations__', {})
     dataclass_fields = kls.__dataclass_fields__
     previous_default = None
@@ -113,6 +118,9 @@ def _build_init(kls):
             elif field.name in remaining_kwargs:
                 value = remaining_kwargs.pop(field.name)
             elif required_for_init:
+                # Keep init-time requiredness separate from dataclass/click defaults.
+                # This is needed for older Python targets because click-backed fields do
+                # not report defaults consistently across 3.9/3.10.
                 missing.append(field.name)
                 continue
             elif field.default is not MISSING:
@@ -130,6 +138,7 @@ def _build_init(kls):
             if field.name in remaining_kwargs:
                 value = remaining_kwargs.pop(field.name)
             elif required_for_init:
+                # Same cross-version compatibility path as above; drop with old-Python support.
                 missing.append(field.name)
                 continue
             elif field.default is not MISSING:
@@ -177,6 +186,10 @@ def _field_has_python_default(field):
 
 def _field_is_required_for_init(field):
     if isinstance(field, Option):
+        # Python 3.9/3.10 differ in how click-derived defaults surface on Option fields:
+        # prompted options may look like they default to None on 3.9, while plain options
+        # can stay as click.UNSET on 3.10. Base requiredness on explicit user intent so this
+        # branch can be removed when older Python compatibility is no longer needed.
         has_explicit_default = 'default' in field.attrs or field.default_factory is not MISSING
         if field.attrs.get('required', False):
             return not has_explicit_default

--- a/classyclick/utils.py
+++ b/classyclick/utils.py
@@ -177,11 +177,14 @@ def _field_has_python_default(field):
 
 def _field_is_required_for_init(field):
     if isinstance(field, Option):
+        has_explicit_default = 'default' in field.attrs or field.default_factory is not MISSING
         if field.attrs.get('required', False):
-            return 'default' not in field.attrs and field.default_factory is MISSING
-        if field.attrs.get('prompt') and 'default' not in field.attrs and field.default_factory is MISSING:
+            return not has_explicit_default
+        if field.attrs.get('prompt') and not has_explicit_default:
             return True
-        return not _field_has_python_default(field)
+        if _field_has_python_default(field):
+            return False
+        return False
     if isinstance(field, Argument):
         if _field_has_python_default(field):
             return False

--- a/tests/test_command.py
+++ b/tests/test_command.py
@@ -52,6 +52,20 @@ class Test(BaseCase):
         self.assertEqual(obj.name, 'John')
         self.assertEqual(obj.age, 10)
 
+    def test_prompted_option_is_required_for_object_init_without_explicit_default(self):
+        class Hello(classyclick.Command):
+            name: str = classyclick.Option(prompt='Your name')
+            age: int = classyclick.Option(default=10)
+
+            def __call__(self): ...
+
+        with self.assertRaisesRegex(TypeError, "missing 1 required positional argument: 'name'"):
+            Hello()
+
+        obj = Hello('John', 20)
+        self.assertEqual(obj.name, 'John')
+        self.assertEqual(obj.age, 20)
+
     def test_defaults_and_required(self):
         """https://github.com/fopina/classyclick/issues/30"""
 

--- a/tests/test_composition.py
+++ b/tests/test_composition.py
@@ -1,0 +1,21 @@
+import classyclick
+from tests import BaseCase
+
+
+class Test(BaseCase):
+    def test_subclassing_argument_after_base_option_raises_dataclass_error(self):
+        """https://github.com/fopina/classyclick/issues/34"""
+
+        class Base(classyclick.Command):
+            base_arg: str = classyclick.Argument()
+            base_opt: str = classyclick.Option()
+
+            def __call__(self): ...
+
+        with self.assertRaisesRegex(TypeError, "non-default argument 'child_arg' follows default argument 'base_opt'"):
+
+            class Child(Base):
+                child_arg: str = classyclick.Argument()
+                child_opt: str = classyclick.Option()
+
+                def __call__(self): ...

--- a/tests/test_composition.py
+++ b/tests/test_composition.py
@@ -1,21 +1,39 @@
+from click.testing import CliRunner
+
 import classyclick
 from tests import BaseCase
 
 
 class Test(BaseCase):
-    def test_subclassing_argument_after_base_option_raises_dataclass_error(self):
+    def test_subclassing_argument_after_base_option_keeps_working(self):
         """https://github.com/fopina/classyclick/issues/34"""
 
         class Base(classyclick.Command):
             base_arg: str = classyclick.Argument()
-            base_opt: str = classyclick.Option()
+            base_opt: str = classyclick.Option(default='foo')
 
-            def __call__(self): ...
+            def __call__(self):
+                return None
 
-        with self.assertRaisesRegex(TypeError, "non-default argument 'child_arg' follows default argument 'base_opt'"):
+        class Child(Base):
+            child_arg: str = classyclick.Argument()
+            child_opt: str = classyclick.Option(default='bar')
 
-            class Child(Base):
-                child_arg: str = classyclick.Argument()
-                child_opt: str = classyclick.Option()
+            def __call__(self):
+                print(f'{self.base_arg}:{self.base_opt}:{self.child_arg}:{self.child_opt}')
 
-                def __call__(self): ...
+        direct = Child('base', child_arg='child')
+        self.assertEqual(direct.base_arg, 'base')
+        self.assertEqual(direct.base_opt, 'foo')
+        self.assertEqual(direct.child_arg, 'child')
+        self.assertEqual(direct.child_opt, 'bar')
+
+        with self.assertRaisesRegex(TypeError, 'takes 3 positional arguments but 4 were given'):
+            Child('base', 'foo', 'child')
+
+        with self.assertRaisesRegex(TypeError, "missing 1 required positional argument: 'child_arg'"):
+            Child('base', 'foo')
+
+        result = CliRunner().invoke(Child.click, ['base', 'child'])
+        self.assertEqual(result.exit_code, 0)
+        self.assertEqual(result.output, 'base:foo:child:bar\n')

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -1,5 +1,5 @@
-from classyclick import utils
 import classyclick
+from classyclick import utils
 from tests import BaseCase
 
 

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -1,4 +1,5 @@
 from classyclick import utils
+import classyclick
 from tests import BaseCase
 
 
@@ -10,3 +11,9 @@ class Test(BaseCase):
 
     def test_snake_kebab(self):
         self.assertEqual(utils.snake_kebab('dry_run'), 'dry-run')
+
+    def test_group_subclass_without_local_annotations_builds_click_command(self):
+        class Who(classyclick.Group):
+            __config__ = classyclick.Group.Config(name='who')
+
+        self.assertEqual(Who.click.name, 'who')


### PR DESCRIPTION
## Summary
- add a focused regression test for inherited argument/option composition
- capture the current dataclass field-ordering failure from issue #34

Fixes #34