### PR TITLE
docs: document helper utilities

### DIFF
--- a/README.md
+++ b/README.md
@@ -299,6 +299,73 @@ class Next(NextGroupMeta.Command):
         click.echo(self.your_number + self.step_number)
 ```
 
+### classyclick.helpers
+
+`classyclick.helpers` contains optional helpers for larger CLIs.
+
+One useful pattern is a root group that loads config defaults plus a built-in `config` command to inspect them:
+
+```python
+from pathlib import Path
+
+import click
+
+import classyclick
+
+
+class CLI(classyclick.helpers.ConfigFileMixin, classyclick.Group):
+    """Application CLI."""
+
+    __config__ = classyclick.Group.Config(
+        context_settings=dict(show_default=True),
+        decorators=[click.version_option(version='1.2.3', message='%(version)s')],
+    )
+    CONFIG_DEFAULT_NAME = 'my-app'
+    CONFIG_EXAMPLE_PATH = Path(__file__).parent / 'config.example.toml'
+
+    host: str = classyclick.Option(help='Server URL')
+    token: str = classyclick.Option(help='API token')
+    debug: bool = classyclick.Option(help='Enable debug logging')
+
+    def __call__(self):
+        self.load_config()
+
+
+class Config(classyclick.helpers.ConfigBaseCommand, CLI.Command):
+    pass
+
+
+classyclick.helpers.discover_commands(__package__)
+```
+
+`discover_commands()` recursively imports submodules so command classes register themselves under the group when your CLI is split across packages.
+
+`ConfigFileMixin` adds `--config` and `--env`, loads `config.toml`, merges `[env.<name>]` sections, and uses matching keys as defaults for classyclick fields. Explicit command-line flags still win over config values.
+
+`ConfigBaseCommand` is a ready-made command that shows the merged config or opens the active config file in `$VISUAL` or `$EDITOR`.
+
+### config.toml
+
+`config.toml` is meant to mirror your CLI options. Root-level keys become defaults for matching fields, and `default_env` selects a named `[env.<name>]` section to merge on top.
+
+```toml
+default_env = "dev"
+host = "https://api.example.com"
+
+[env.dev]
+token = "dev-token"
+debug = true
+
+[env.prod]
+token = "prod-token"
+```
+
+With this file:
+
+- `my-app status` uses the `dev` environment by default
+- `my-app --env prod status` merges the `prod` overrides over the root config
+- `my-app --env prod --host https://staging.example.com status` still uses `prod`, but the CLI flag overrides `host`
+
 ### Composition
 
 You can compose commands together as the wrapped class is just a `dataclass`.

--- a/README.md
+++ b/README.md
@@ -335,10 +335,13 @@ class Config(classyclick.helpers.ConfigBaseCommand, CLI.Command):
     pass
 
 
+# in package/commands/__init__.py
 classyclick.helpers.discover_commands(__package__)
 ```
 
-`discover_commands()` recursively imports submodules so command classes register themselves under the group when your CLI is split across packages.
+`discover_commands()` is usually called from `package.commands.__init__.py` when each command lives in its own module. It recursively imports submodules so command classes register themselves under the group.
+
+It can also be called from elsewhere, such as `package.__init__.py`, by pointing it at the commands package directly with `classyclick.helpers.discover_commands(f'{__package__}.commands')`.
 
 `ConfigFileMixin` adds `--config` and `--env`, loads `config.toml`, merges `[env.<name>]` sections, and uses matching keys as defaults for classyclick fields. Explicit command-line flags still win over config values.
 

--- a/docs/README.md
+++ b/docs/README.md
@@ -26,6 +26,7 @@ the API reference when you need exact behavior.
   attributes to Click parameters
 - `classyclick.Context`, `classyclick.ContextObj`, and `classyclick.ContextMeta`
   for injecting Click context values onto the command instance
+- `classyclick.helpers` for command auto-discovery and config-backed CLIs
 - `.click` objects generated automatically from those classes
 
 ## Installation

--- a/docs/api.md
+++ b/docs/api.md
@@ -247,7 +247,17 @@ to register its `Group.Command` or `Group.SubGroup` subclasses.
 Typical usage:
 
 ```python
+# in package/commands/__init__.py
 classyclick.helpers.discover_commands(__package__)
+```
+
+This is the usual pattern when each command lives in its own module under a
+`package.commands` package.
+
+It can also be called from somewhere else, such as `package.__init__.py`:
+
+```python
+classyclick.helpers.discover_commands(f'{__package__}.commands')
 ```
 
 ### `ConfigFileMixin`

--- a/docs/api.md
+++ b/docs/api.md
@@ -12,6 +12,7 @@ The top-level `classyclick` package re-exports the main public API from
 - `Command`
 - `Group`
 - `Option`, `Argument`, `Context`, `ContextObj`, `ContextMeta`
+- `helpers`
 
 Importing from the package root is the intended user-facing style.
 
@@ -229,6 +230,109 @@ It:
 
 Internal helper that walks the class MRO looking for inherited group-binding
 configuration.
+
+## `classyclick.helpers`
+
+Helper utilities built on top of the core `Command` and `Group` APIs.
+
+These are exported as `classyclick.helpers`.
+
+### `discover_commands(commands_package)`
+
+Imports every module below the given package, including nested subpackages.
+
+This is mainly useful for class-based groups where importing a module is enough
+to register its `Group.Command` or `Group.SubGroup` subclasses.
+
+Typical usage:
+
+```python
+classyclick.helpers.discover_commands(__package__)
+```
+
+### `ConfigFileMixin`
+
+Mixin for commands or groups that load option defaults from a `config.toml`
+file.
+
+It adds three fields:
+
+- `config`: path to the configuration file
+- `env`: optional environment name to select from `config.toml`
+- `ctx`: injected Click context used to publish loaded config metadata
+
+Subclasses are expected to configure:
+
+- `CONFIG_DEFAULT_NAME`: application name used to derive the user config
+  directory when `CONFIG_DEFAULT_PATH` is not overridden
+- `CONFIG_DEFAULT_PATH`: full default path to the config file
+- `CONFIG_EXAMPLE_PATH`: path to a bundled example config file, or `False` to
+  disable auto-creation
+
+Behavior:
+
+- if the config file does not exist and `CONFIG_EXAMPLE_PATH` is set, the file
+  is created from that example
+- root config values act as defaults for matching `classyclick` fields
+- `default_env` provides the default value for `--env`
+- `[env.<name>]` sections are merged over the root config when an environment is
+  selected
+- explicit CLI values still take precedence over config values
+
+After loading, the mixin stores extra data on `ctx.meta`:
+
+- `config_path`: resolved path to the loaded config file
+- `config_data`: merged configuration data after environment selection
+- `selected_env`: chosen environment name, if any
+
+It also assigns the merged config to `ctx.default_map` so Click can use the
+same defaults during parsing.
+
+### `ConfigFileMixin.ensure_config_file(config_path)`
+
+Resolves the path to use, creates parent directories when needed, and
+optionally copies the example config file into place.
+
+### `ConfigFileMixin.load_config_data(config_path)`
+
+Reads and parses the TOML configuration file.
+
+Override this if your application needs custom loading behavior.
+
+### `ConfigFileMixin.load_config()`
+
+Loads the config file, applies environment merging, copies matching config
+values into unset command fields, and publishes the result on the Click
+context.
+
+Applications typically call this near the start of `__call__()`.
+
+### `ConfigBaseCommand`
+
+Reusable command base that shows or edits the currently loaded configuration.
+
+It expects a `ConfigFileMixin`-based parent command or group to have already
+loaded config metadata into `ctx.meta`.
+
+By default it:
+
+- prints the active config file path
+- prints the selected environment when one is active
+- dumps the merged configuration as formatted JSON
+- masks values whose keys match `token` or `password`
+- opens the config file in `$VISUAL` or `$EDITOR` when `--edit` is used
+
+### `ConfigBaseCommand.MASKED`
+
+Replacement string used when masked config values are displayed.
+
+Defaults to `'<masked>'`.
+
+### `ConfigBaseCommand.MASKED_FIELDS`
+
+Sequence of field names that should be masked in output.
+
+Defaults to `('token', 'password')`.
 
 ## `classyclick.utils`
 

--- a/docs/guide.md
+++ b/docs/guide.md
@@ -197,6 +197,7 @@ to register their `Group.Command` and `Group.SubGroup` subclasses.
 `classyclick.helpers.discover_commands()` automates that import step:
 
 ```python
+# in package/commands/__init__.py
 import classyclick
 
 
@@ -207,7 +208,17 @@ class CLI(classyclick.Group):
 classyclick.helpers.discover_commands(__package__)
 ```
 
-This walks the package recursively and imports each module once.
+This is the common pattern when each command lives in its own module under a
+`package.commands` package.
+
+It walks the package recursively and imports each module once.
+
+You can also call it from somewhere else, such as `package.__init__.py`, by
+pointing it at the commands package explicitly:
+
+```python
+classyclick.helpers.discover_commands(f'{__package__}.commands')
+```
 
 ### Config-backed CLIs
 

--- a/docs/guide.md
+++ b/docs/guide.md
@@ -177,11 +177,115 @@ When a `Group` subclass is created, `classyclick`:
 
 - builds a `click.Group` and stores it as `.click`
 - creates `Group.Command` and `Group.SubGroup` helper base classes
+- also exposes `Group.CommandMixin` and `Group.SubGroupMixin` for cases where
+  you need to combine the group binding with your own command/group base class
 - binds those helper bases so child commands and sub-groups register beneath the
   parent group automatically
 
 This gives you a compact way to build nested CLIs while keeping each command as
 its own class.
+
+## Helper utilities
+
+`classyclick.helpers` contains optional building blocks for larger CLIs.
+
+### Auto-discover command modules
+
+When a CLI is split across many modules, importing those modules is often enough
+to register their `Group.Command` and `Group.SubGroup` subclasses.
+
+`classyclick.helpers.discover_commands()` automates that import step:
+
+```python
+import classyclick
+
+
+class CLI(classyclick.Group):
+    """Application CLI."""
+
+
+classyclick.helpers.discover_commands(__package__)
+```
+
+This walks the package recursively and imports each module once.
+
+### Config-backed CLIs
+
+`classyclick.helpers.ConfigFileMixin` lets a command or group load defaults from
+`config.toml`.
+
+A common pattern is:
+
+```python
+from pathlib import Path
+
+import click
+
+import classyclick
+
+
+class CLI(classyclick.helpers.ConfigFileMixin, classyclick.Group):
+    """Application CLI."""
+
+    __config__ = classyclick.Group.Config(
+        context_settings=dict(show_default=True),
+        decorators=[click.version_option(version='1.2.3', message='%(version)s')],
+    )
+    CONFIG_DEFAULT_NAME = 'my-app'
+    CONFIG_EXAMPLE_PATH = Path(__file__).parent / 'config.example.toml'
+
+    host: str = classyclick.Option(help='Server URL')
+    token: str = classyclick.Option(help='API token')
+    debug: bool = classyclick.Option(help='Enable debug logging')
+
+    def __call__(self):
+        self.load_config()
+
+
+class Config(classyclick.helpers.ConfigBaseCommand, CLI.Command):
+    """Show or edit the current CLI configuration."""
+
+
+classyclick.helpers.discover_commands(__package__)
+```
+
+The mixin adds `--config` and `--env` options and a `ctx` field automatically.
+Call `self.load_config()` before you use config-backed values.
+
+`ConfigBaseCommand` is an optional helper command that prints the merged config
+or opens the file in `$VISUAL` / `$EDITOR`.
+
+### `config.toml` behavior
+
+The config file is intentionally aligned with the CLI:
+
+- root-level keys act as defaults for matching `classyclick` fields
+- command-line flags still win over config values
+- `--config` only selects which file to read, so it is not itself stored inside
+  `config.toml`
+- `--env` selects an `[env.<name>]` section, while `default_env` provides the
+  default environment value
+
+Example:
+
+```toml
+default_env = "dev"
+host = "https://api.example.com"
+
+[env.dev]
+token = "dev-token"
+debug = true
+
+[env.prod]
+token = "prod-token"
+```
+
+With this file:
+
+- `my-app status` uses the `dev` environment because of `default_env`
+- `my-app --env prod status` merges `[env.prod]` over the root config
+- `my-app --env prod --host https://staging.example.com status` still uses the
+  `prod` config, but the CLI flag overrides `host`
 
 ## Required field ordering
 


### PR DESCRIPTION
## Summary
- document classyclick.helpers in the README and docs landing page
- add guide coverage for discover_commands, ConfigFileMixin, ConfigBaseCommand, and generic config.toml behavior
- expand the API reference to cover the exported helper utilities and note the group mixin compatibility path

## Testing
- not run (docs-only changes)
