### PR TITLE
Fix dataclass mixin options in composed commands

### DIFF
--- a/classyclick/utils.py
+++ b/classyclick/utils.py
@@ -98,6 +98,7 @@ def _build_init(kls):
         if not _field_is_required_for_init(field):
             break
     positional_fields = tuple(positional_fields)
+    positional_field_names = {field.name for field in positional_fields}
 
     def __init__(self, *args, **kwargs):
         if len(args) > len(positional_fields):
@@ -133,7 +134,9 @@ def _build_init(kls):
 
             setattr(self, field.name, value)
 
-        for field in init_fields[len(positional_fields) :]:
+        for field in init_fields:
+            if field.name in positional_field_names:
+                continue
             required_for_init = _field_is_required_for_init(field)
             if field.name in remaining_kwargs:
                 value = remaining_kwargs.pop(field.name)

--- a/tests/test_composition.py
+++ b/tests/test_composition.py
@@ -1,3 +1,5 @@
+from dataclasses import dataclass
+
 from click.testing import CliRunner
 
 import classyclick
@@ -37,3 +39,19 @@ class Test(BaseCase):
         result = CliRunner().invoke(Child.click, ['base', 'child'])
         self.assertEqual(result.exit_code, 0)
         self.assertEqual(result.output, 'base:foo:child:bar\n')
+
+    def test_command_supports_dataclass_mixin_with_classyclick_option(self):
+        """https://github.com/fopina/classyclick/issues/71"""
+
+        @dataclass(kw_only=True)
+        class BaseMixin:
+            debug: bool = classyclick.Option()
+
+        class FixMe(classyclick.Command, BaseMixin):
+            some_flag: bool = classyclick.Option()
+
+            def __call__(self):
+                print(f'debug={self.debug} some_flag={self.some_flag}')
+
+        result = CliRunner().invoke(FixMe.click, ['--debug', '--some-flag'])
+        self.assertEqual(result.exit_code, 0, result.exception or result.output)

--- a/tests/test_composition.py
+++ b/tests/test_composition.py
@@ -1,3 +1,4 @@
+import sys
 from dataclasses import dataclass
 
 from click.testing import CliRunner
@@ -42,6 +43,8 @@ class Test(BaseCase):
 
     def test_command_supports_dataclass_mixin_with_classyclick_option(self):
         """https://github.com/fopina/classyclick/issues/71"""
+        if sys.version_info < (3, 10):
+            self.skipTest('dataclass kw_only requires Python 3.10+')
 
         @dataclass(kw_only=True)
         class BaseMixin:


### PR DESCRIPTION
## Summary
- add a regression test from issue #71 for a dataclass kw_only mixin that declares a classyclick Option
- fix custom command init building so inherited keyword-only dataclass fields are still consumed
- keep existing positional argument behavior intact for normal classyclick command fields

## Testing
- uv run pytest tests/test_composition.py
- uv run pytest tests/test_command.py tests/test_command_option.py tests/test_group.py

Fixes #71