### PR TITLE
Fix variadic Argument typing for issue #35

### DIFF
--- a/classyclick/fields.py
+++ b/classyclick/fields.py
@@ -27,10 +27,20 @@ class _Field(DataclassField):
     def infer_type(self):
         if 'type' not in self.attrs:
             nargs = self.attrs.get('nargs', 1)
-            if (self.attrs.get('multiple', False) or nargs not in (None, 1)) and get_origin(self.type) is list:
-                self.attrs['type'] = get_args(self.type)[0]
-            else:
-                self.attrs['type'] = self.type
+            inferred_type = self.type
+            if self.attrs.get('multiple', False) or nargs not in (None, 1):
+                origin = get_origin(self.type)
+                args = get_args(self.type)
+                if origin is list and len(args) == 1:
+                    inferred_type = args[0]
+                elif origin is tuple:
+                    if len(args) == 1:
+                        inferred_type = args[0]
+                    elif len(args) == 2 and args[1] is Ellipsis:
+                        inferred_type = args[0]
+                    elif isinstance(nargs, int) and nargs > 1 and len(args) == nargs:
+                        inferred_type = args
+            self.attrs['type'] = inferred_type
 
     def get_type(self):
         return self._click_type

--- a/classyclick/fields.py
+++ b/classyclick/fields.py
@@ -26,7 +26,8 @@ class _Field(DataclassField):
 
     def infer_type(self):
         if 'type' not in self.attrs:
-            if (self.attrs.get('multiple', False) or self.attrs.get('nargs', 1) > 1) and get_origin(self.type) is list:
+            nargs = self.attrs.get('nargs', 1)
+            if (self.attrs.get('multiple', False) or nargs not in (None, 1)) and get_origin(self.type) is list:
                 self.attrs['type'] = get_args(self.type)[0]
             else:
                 self.attrs['type'] = self.type

--- a/tests/test_command_argument.py
+++ b/tests/test_command_argument.py
@@ -117,6 +117,23 @@ Options:
         )
 
     def test_type_list_nargs_variadic(self):
+        """https://github.com/fopina/classyclick/issues/35"""
+
+        # confirm Option multiple=True still works (as it did before the fix)
+        class DP(classyclick.Command):
+            other_attachments: list[str] = classyclick.Option('-o', multiple=True)
+
+            def __call__(self):
+                print(repr(self.other_attachments))
+
+        runner = CliRunner()
+
+        result = runner.invoke(DP.click, ['-o', 'asd', '-o', 'qwe'])
+        self.assertEqual(result.exception, None)
+        self.assertEqual(result.exit_code, 0)
+        self.assertEqual(result.output, "('asd', 'qwe')\n")
+
+        # confirm issue is fixed
         class DP(classyclick.Command):
             other_attachments: list[str] = classyclick.Argument(nargs=-1)
 

--- a/tests/test_command_argument.py
+++ b/tests/test_command_argument.py
@@ -128,7 +128,7 @@ class TestIssue35(BaseCase):
             def __call__(self):
                 print(repr(self.p1), repr(self.p2))
 
-        runner = CliRunner(catch_exceptions=False)
+        runner = CliRunner()
         result = runner.invoke(DP.click, ['-a', 'asd', '-a', 'qwe', '-b', 'foo', 'bar'])
         self.assertEqual(result.exception, None)
         self.assertEqual(result.exit_code, 0)
@@ -141,7 +141,7 @@ class TestIssue35(BaseCase):
             def __call__(self):
                 print(repr(self.other_attachments))
 
-        runner = CliRunner(catch_exceptions=False)
+        runner = CliRunner()
         result = runner.invoke(DP.click, ['asd', 'qwe'])
         self.assertEqual(result.exception, None)
         self.assertEqual(result.exit_code, 0)
@@ -154,7 +154,7 @@ class TestIssue35(BaseCase):
             def __call__(self):
                 print(repr(self.other_attachments))
 
-        runner = CliRunner(catch_exceptions=False)
+        runner = CliRunner()
         result = runner.invoke(DP.click, ['asd', 'qwe'])
         self.assertEqual(result.exception, None)
         self.assertEqual(result.exit_code, 0)
@@ -167,7 +167,7 @@ class TestIssue35(BaseCase):
             def __call__(self):
                 print(repr(self.other_attachments))
 
-        runner = CliRunner(catch_exceptions=False)
+        runner = CliRunner()
         result = runner.invoke(DP.click, ['asd', '1'])
         self.assertEqual(result.exception, None)
         self.assertEqual(result.exit_code, 0)

--- a/tests/test_command_argument.py
+++ b/tests/test_command_argument.py
@@ -115,3 +115,17 @@ Options:
             ),
             (None, 0, 'Hello, john and paul\n'),
         )
+
+    def test_type_list_nargs_variadic(self):
+        class DP(classyclick.Command):
+            other_attachments: list[str] = classyclick.Argument(nargs=-1)
+
+            def __call__(self):
+                print(repr(self.other_attachments))
+
+        runner = CliRunner()
+
+        result = runner.invoke(DP.click, ['asd', 'qwe'])
+        self.assertEqual(result.exception, None)
+        self.assertEqual(result.exit_code, 0)
+        self.assertEqual(result.output, "('asd', 'qwe')\n")

--- a/tests/test_command_argument.py
+++ b/tests/test_command_argument.py
@@ -121,26 +121,25 @@ Options:
 
         # confirm Option multiple=True still works (as it did before the fix)
         class DP(classyclick.Command):
-            other_attachments: list[str] = classyclick.Option('-o', multiple=True)
+            p1: list[str] = classyclick.Option('-a', multiple=True)
+            p2: list[str] = classyclick.Option('-b', nargs=2)
 
             def __call__(self):
-                print(repr(self.other_attachments))
+                print(repr(self.p1), repr(self.p2))
 
-        runner = CliRunner()
+        runner = CliRunner(catch_exceptions=False)
 
-        result = runner.invoke(DP.click, ['-o', 'asd', '-o', 'qwe'])
+        result = runner.invoke(DP.click, ['-a', 'asd', '-a', 'qwe', '-b', 'foo', 'bar'])
         self.assertEqual(result.exception, None)
         self.assertEqual(result.exit_code, 0)
-        self.assertEqual(result.output, "('asd', 'qwe')\n")
+        self.assertEqual(result.output, "('asd', 'qwe') ('foo', 'bar')\n")
 
         # confirm issue is fixed
         class DP(classyclick.Command):
-            other_attachments: list[str] = classyclick.Argument(nargs=-1)
+            other_attachments: list[str] = classyclick.Argument(nargs=2)
 
             def __call__(self):
                 print(repr(self.other_attachments))
-
-        runner = CliRunner()
 
         result = runner.invoke(DP.click, ['asd', 'qwe'])
         self.assertEqual(result.exception, None)

--- a/tests/test_command_argument.py
+++ b/tests/test_command_argument.py
@@ -116,10 +116,11 @@ Options:
             (None, 0, 'Hello, john and paul\n'),
         )
 
-    def test_type_list_nargs_variadic(self):
-        """https://github.com/fopina/classyclick/issues/35"""
 
-        # confirm Option multiple=True still works (as it did before the fix)
+class TestIssue35(BaseCase):
+    """https://github.com/fopina/classyclick/issues/35"""
+
+    def test_option_multiple_and_nargs_still_work(self):
         class DP(classyclick.Command):
             p1: list[str] = classyclick.Option('-a', multiple=True)
             p2: list[str] = classyclick.Option('-b', nargs=2)
@@ -128,20 +129,46 @@ Options:
                 print(repr(self.p1), repr(self.p2))
 
         runner = CliRunner(catch_exceptions=False)
-
         result = runner.invoke(DP.click, ['-a', 'asd', '-a', 'qwe', '-b', 'foo', 'bar'])
         self.assertEqual(result.exception, None)
         self.assertEqual(result.exit_code, 0)
         self.assertEqual(result.output, "('asd', 'qwe') ('foo', 'bar')\n")
 
-        # confirm issue is fixed
+    def test_argument_with_fixed_nargs_and_list_annotation(self):
         class DP(classyclick.Command):
             other_attachments: list[str] = classyclick.Argument(nargs=2)
 
             def __call__(self):
                 print(repr(self.other_attachments))
 
+        runner = CliRunner(catch_exceptions=False)
         result = runner.invoke(DP.click, ['asd', 'qwe'])
         self.assertEqual(result.exception, None)
         self.assertEqual(result.exit_code, 0)
         self.assertEqual(result.output, "('asd', 'qwe')\n")
+
+    def test_argument_with_variadic_nargs_and_tuple_annotation(self):
+        class DP(classyclick.Command):
+            other_attachments: tuple[str, ...] = classyclick.Argument(nargs=-1)
+
+            def __call__(self):
+                print(repr(self.other_attachments))
+
+        runner = CliRunner(catch_exceptions=False)
+        result = runner.invoke(DP.click, ['asd', 'qwe'])
+        self.assertEqual(result.exception, None)
+        self.assertEqual(result.exit_code, 0)
+        self.assertEqual(result.output, "('asd', 'qwe')\n")
+
+    def test_argument_with_fixed_nargs_and_fixed_tuple_annotation(self):
+        class DP(classyclick.Command):
+            other_attachments: tuple[str, int] = classyclick.Argument(nargs=2)
+
+            def __call__(self):
+                print(repr(self.other_attachments))
+
+        runner = CliRunner(catch_exceptions=False)
+        result = runner.invoke(DP.click, ['asd', '1'])
+        self.assertEqual(result.exception, None)
+        self.assertEqual(result.exit_code, 0)
+        self.assertEqual(result.output, "('asd', 1)\n")


### PR DESCRIPTION
## Summary
- fix `Argument(nargs=-1)` type inference for `list[T]` annotations
- keep `nargs=None` behaving like Click's default single-value argument
- add regression coverage for the issue #35 variadic argument case

## Testing
- uv run pytest tests/test_command_argument.py -q
- uv run pytest tests/test_command_option.py -q
- make lint-check

Closes #35