### PR TITLE
test: add Python 3.14 to CI matrix

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -54,7 +54,7 @@ jobs:
     strategy:
       matrix:
         # 3.10 added as there are "unique" issues in it (such as Path requiring str() for many core methods)
-        python-version: ['3.9', '3.10', '3.12', '3.13']
+        python-version: ['3.9', '3.10', '3.12', '3.13', '3.14']
         click-version: ['==7.0', '>8']
     steps:
       - name: Checkout

--- a/classyclick/fields.py
+++ b/classyclick/fields.py
@@ -1,4 +1,4 @@
-import inspect
+import sys
 from dataclasses import MISSING
 from dataclasses import Field as DataclassField
 from typing import TYPE_CHECKING, Any, get_args, get_origin
@@ -9,9 +9,9 @@ if TYPE_CHECKING:
 from . import utils
 
 _EXTRA_DATACLASS_INIT = dict(default_factory=MISSING, init=True, repr=True, hash=None, compare=True, metadata=None)
-if 'kw_only' in inspect.signature(DataclassField).parameters:
+if sys.version_info >= (3, 10):
     _EXTRA_DATACLASS_INIT['kw_only'] = MISSING
-if 'doc' in inspect.signature(DataclassField).parameters:
+if sys.version_info >= (3, 14):
     _EXTRA_DATACLASS_INIT['doc'] = None
 
 

--- a/classyclick/fields.py
+++ b/classyclick/fields.py
@@ -1,4 +1,4 @@
-import sys
+import inspect
 from dataclasses import MISSING
 from dataclasses import Field as DataclassField
 from typing import TYPE_CHECKING, Any, get_args, get_origin
@@ -9,8 +9,10 @@ if TYPE_CHECKING:
 from . import utils
 
 _EXTRA_DATACLASS_INIT = dict(default_factory=MISSING, init=True, repr=True, hash=None, compare=True, metadata=None)
-if sys.version_info >= (3, 10):
+if 'kw_only' in inspect.signature(DataclassField).parameters:
     _EXTRA_DATACLASS_INIT['kw_only'] = MISSING
+if 'doc' in inspect.signature(DataclassField).parameters:
+    _EXTRA_DATACLASS_INIT['doc'] = None
 
 
 class _Field(DataclassField):

--- a/classyclick/utils.py
+++ b/classyclick/utils.py
@@ -50,11 +50,23 @@ def get_inherited_doc(kls):
     return doc
 
 
-def strictly_typed_dataclass(kls):
+def _local_annotations(kls):
     # Python 3.9 can expose inherited annotations via getattr(..., '__annotations__'),
-    # which makes base helper attributes like `click` look like local dataclass fields.
-    # Once Python 3.9 support is dropped, revisit whether this can be simplified.
-    annotations = kls.__dict__.get('__annotations__', {})
+    # which makes base helper attributes look like local dataclass fields.
+    annotations = kls.__dict__.get('__annotations__')
+    if annotations is not None:
+        return annotations
+
+    # Python 3.14 may not populate __dict__['__annotations__'] until accessed,
+    # but classes that define annotations expose __annotate_func__ in __dict__.
+    if '__annotate_func__' in kls.__dict__:
+        return getattr(kls, '__annotations__', {})
+
+    return {}
+
+
+def strictly_typed_dataclass(kls):
+    annotations = _local_annotations(kls)
     for name, val in kls.__dict__.items():
         if name.startswith('__'):
             continue
@@ -67,9 +79,9 @@ def strictly_typed_dataclass(kls):
 
 
 def _validate_local_field_order(kls):
-    # Same Python 3.9 compatibility note as in strictly_typed_dataclass():
+    # Same compatibility note as in strictly_typed_dataclass():
     # only consider annotations declared on this class body.
-    local_annotations = kls.__dict__.get('__annotations__', {})
+    local_annotations = _local_annotations(kls)
     dataclass_fields = kls.__dataclass_fields__
     previous_default = None
     for name in local_annotations:


### PR DESCRIPTION
## Summary
- add Python 3.14 to the GitHub Actions test matrix
- let CI reproduce the reported Python 3.14 failure in issue #75

## Testing
- validated workflow YAML parses
- ran local pytest and reproduced the Python 3.14 import failure during test collection

Fixes #75